### PR TITLE
feat: 공고 랜덤 3개 조회 API 구현 (#17)

### DIFF
--- a/src/main/java/com/startingblock/domain/announcement/application/AnnouncementService.java
+++ b/src/main/java/com/startingblock/domain/announcement/application/AnnouncementService.java
@@ -7,11 +7,14 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 public interface AnnouncementService {
 
     void refreshAnnouncements(UserPrincipal userPrincipal);
     Slice<AnnouncementRes> findAnnouncements(UserPrincipal userPrincipal, Pageable pageable, String businessAge, String region, String supportType, String sort, String search);
-    AnnouncementDetailRes findAnnouncementDetailById(Long announcementId);
+    AnnouncementDetailRes findAnnouncementDetailById(UserPrincipal userPrincipal, Long announcementId);
+    List<AnnouncementRes> findThreeRandomAnnouncement(UserPrincipal userPrincipal);
 
 }

--- a/src/main/java/com/startingblock/domain/announcement/application/AnnouncementServiceImpl.java
+++ b/src/main/java/com/startingblock/domain/announcement/application/AnnouncementServiceImpl.java
@@ -8,6 +8,9 @@ import com.startingblock.domain.announcement.dto.AnnouncementRes;
 import com.startingblock.domain.announcement.exception.InvalidAnnouncementException;
 import com.startingblock.domain.announcement.exception.PermissionDeniedException;
 import com.startingblock.domain.user.domain.Role;
+import com.startingblock.domain.user.domain.User;
+import com.startingblock.domain.user.domain.repository.UserRepository;
+import com.startingblock.domain.user.exception.InvalidUserException;
 import com.startingblock.global.config.FeignConfig;
 import com.startingblock.global.config.security.token.UserPrincipal;
 import com.startingblock.global.infrastructure.feign.BizInfoClient;
@@ -33,6 +36,7 @@ import java.util.Objects;
 @Slf4j
 @Transactional(readOnly = true)
 public class AnnouncementServiceImpl implements AnnouncementService {
+    private final UserRepository userRepository;
 
     private final FeignConfig feignConfig;
     private final AnnouncementRepository announcementRepository;
@@ -157,11 +161,18 @@ public class AnnouncementServiceImpl implements AnnouncementService {
     }
 
     @Override
-    public AnnouncementDetailRes findAnnouncementDetailById(Long announcementId) {
-        Announcement announcement = announcementRepository.findById(announcementId)
-                .orElseThrow(InvalidAnnouncementException::new);
+    public AnnouncementDetailRes findAnnouncementDetailById(UserPrincipal userPrincipal, Long announcementId) {
+        AnnouncementDetailRes announcementDetail = announcementRepository.findAnnouncementDetail(userPrincipal.getId(), announcementId);
 
-        return AnnouncementDetailRes.of(announcement);
+        if(announcementDetail == null)
+            throw new InvalidAnnouncementException();
+
+        return announcementDetail;
+    }
+
+    @Override
+    public List<AnnouncementRes> findThreeRandomAnnouncement(UserPrincipal userPrincipal) {
+        return announcementRepository.findThreeRandomAnnouncement(userPrincipal.getId());
     }
 
 }

--- a/src/main/java/com/startingblock/domain/announcement/domain/repository/AnnouncementQuerydslRepository.java
+++ b/src/main/java/com/startingblock/domain/announcement/domain/repository/AnnouncementQuerydslRepository.java
@@ -1,5 +1,6 @@
 package com.startingblock.domain.announcement.domain.repository;
 
+import com.startingblock.domain.announcement.dto.AnnouncementDetailRes;
 import com.startingblock.domain.announcement.dto.AnnouncementRes;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -10,5 +11,7 @@ public interface AnnouncementQuerydslRepository {
 
     List<String> findAnnouncementPostIds();
     Slice<AnnouncementRes> findAnnouncements(Long userId, Pageable pageable, String businessAge, String region, String supportType, String sort, String search);
+    AnnouncementDetailRes findAnnouncementDetail(Long userId, Long announcementId);
+    List<AnnouncementRes> findThreeRandomAnnouncement(Long userId);
 
 }

--- a/src/main/java/com/startingblock/domain/announcement/dto/AnnouncementDetailRes.java
+++ b/src/main/java/com/startingblock/domain/announcement/dto/AnnouncementDetailRes.java
@@ -1,16 +1,15 @@
 package com.startingblock.domain.announcement.dto;
 
+import com.querydsl.core.annotations.QueryProjection;
 import com.startingblock.domain.announcement.domain.Announcement;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
 @Data
-@AllArgsConstructor
-@Builder
 public class AnnouncementDetailRes {
 
     private Long id;
+    private Boolean isBookmarked;
     private String organization;
     private String title;
     private String content;
@@ -21,7 +20,6 @@ public class AnnouncementDetailRes {
     private String supportType;
     private String link;
     private String region;
-    private String postTarget;
     private Integer saved;
     private String classification;
     private String contact;
@@ -39,11 +37,30 @@ public class AnnouncementDetailRes {
                 .supportType(announcement.getSupportType())
                 .link(announcement.getDetailUrl())
                 .region(announcement.getAreaName())
-                .postTarget(announcement.getPostTarget())
                 .saved(announcement.getRoadmapCount())
                 .classification(announcement.getAnnouncementType().toString())
                 .contact(announcement.getContact())
                 .build();
+    }
+
+    @Builder
+    @QueryProjection
+    public AnnouncementDetailRes(Long id, Boolean isBookmarked, String organization, String title, String content, String startDate, String endDate, String target, String targetAge, String supportType, String link, String region, Integer saved, String classification, String contact) {
+        this.id = id;
+        this.isBookmarked = isBookmarked;
+        this.organization = organization;
+        this.title = title;
+        this.content = content;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.target = target;
+        this.targetAge = targetAge;
+        this.supportType = supportType;
+        this.link = link;
+        this.region = region;
+        this.saved = saved;
+        this.classification = classification;
+        this.contact = contact;
     }
 
 }

--- a/src/main/java/com/startingblock/domain/announcement/presentation/AnnouncementController.java
+++ b/src/main/java/com/startingblock/domain/announcement/presentation/AnnouncementController.java
@@ -21,6 +21,8 @@ import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 
 @Tag(name = "Announcements API", description = "Announcements API")
 @RequestMapping("/api/v1/announcements")
@@ -68,9 +70,22 @@ public class AnnouncementController {
     })
     @GetMapping("/{announcement-id}")
     public ResponseEntity<AnnouncementDetailRes> findAnnouncementDetailById(
+            @Parameter(name = "Authorization Token") @CurrentUser final UserPrincipal userPrincipal,
             @Parameter(name = "announcement-id", required = true) @PathVariable(name = "announcement-id") final Long announcementId
     ) {
-        return ResponseEntity.ok(announcementService.findAnnouncementDetailById(announcementId));
+        return ResponseEntity.ok(announcementService.findAnnouncementDetailById(userPrincipal, announcementId));
+    }
+
+    @Operation(summary = "공고 랜덤 3개 조회", description = "공고 랜덤 3개 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "공고 랜덤 3개 조회 성공", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = AnnouncementDetailRes.class))}),
+            @ApiResponse(responseCode = "400", description = "공고 랜덤 3개 조회 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})
+    })
+    @GetMapping("/random")
+    public ResponseEntity<List<AnnouncementRes>> findThreeRandomAnnouncement(
+            @Parameter(name = "Authorization Token") @CurrentUser final UserPrincipal userPrincipal
+    ) {
+        return ResponseEntity.ok(announcementService.findThreeRandomAnnouncement(userPrincipal));
     }
 
 }


### PR DESCRIPTION
* feat: 공고 조건별 조회 API 구현

* fix: 공고 조회 API 쿼리 수정

* feat: 공고 상세 정보 조회 API 구현

* fix: 공고 리스트 조회 관련 Sort 방식 수정

* feat: 로드맵 추가 / 삭제

* feat: 로드맵 리스트 API 구현

* chore: swagger 수정

* feat: 공고 랜덤 3개 조회 API 구현

- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.`
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?
## 작업 내용

## 스크린샷

## 주의사항

Closes #{이슈 번호}