### PR TITLE
fix: 질문 상세 조회 api - 하트 취소 관련 에러 수정

### DIFF
--- a/src/main/java/com/startingblock/domain/question/application/QuestionFindService.java
+++ b/src/main/java/com/startingblock/domain/question/application/QuestionFindService.java
@@ -5,19 +5,18 @@ import com.startingblock.domain.announcement.exception.InvalidAnnouncementExcept
 import com.startingblock.domain.answer.domain.repository.AnswerRepository;
 import com.startingblock.domain.heart.domain.Heart;
 import com.startingblock.domain.heart.domain.repository.HeartRepository;
-import com.startingblock.domain.heart.exception.NotExistsHeartException;
 import com.startingblock.domain.question.domain.QAType;
 import com.startingblock.domain.question.domain.Question;
 import com.startingblock.domain.question.domain.repository.QuestionRepository;
 import com.startingblock.domain.question.dto.QuestionResponseDto;
 import com.startingblock.domain.question.exception.InvalidQuestionException;
-import com.startingblock.domain.user.domain.repository.UserRepository;
 import com.startingblock.global.config.security.token.UserPrincipal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -42,8 +41,7 @@ public class QuestionFindService {
     public QuestionResponseDto.QuestionDetailResponse findDetail(final UserPrincipal userPrincipal, final Long questionId) {
         Question question = questionRepository.findById(questionId)
                 .orElseThrow(InvalidQuestionException::new);
-        Heart heart = heartRepository.findByUserIdAndQuestionId(userPrincipal.getId(), questionId)
-                .orElseThrow(NotExistsHeartException::new);
+        Optional<Heart> heart = heartRepository.findByUserIdAndQuestionId(userPrincipal.getId(), questionId);
 
         return QuestionResponseDto.QuestionDetailResponse.builder()
                 .userName(question.getUser().getName())
@@ -51,7 +49,7 @@ public class QuestionFindService {
                 .createdAt(question.getCreatedAt())
                 .heartCount(heartRepository.countByQuestionId(questionId))
                 .isMyHeart(heartRepository.existsByQuestionIdAndUserId(questionId, userPrincipal.getId()))
-                .heartId(heart.getId())
+                .heartId(heart.isPresent() ? heart.get().getId() : null)
                 .contactAnswer(answerRepository.findContactAnswer(questionId))
                 .answerCount(answerRepository.countByQuestionIdAndAnswerType(questionId, QAType.GENERAL))
                 .answerList(answerRepository.findAnswerList(questionId, userPrincipal.getId()))


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.`
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
## 작업 내용
- 질문 상세 조회 api 호출 시 하트 취소 관련 에러를 수정

## 스크린샷

## 주의사항

Closes #36 