### PR TITLE
feat: 로드맵에 담긴 교외 공고 리스트 조회 API 구현 (#43)

### DIFF
--- a/src/main/java/com/startingblock/domain/announcement/domain/repository/AnnouncementQuerydslRepository.java
+++ b/src/main/java/com/startingblock/domain/announcement/domain/repository/AnnouncementQuerydslRepository.java
@@ -1,5 +1,6 @@
 package com.startingblock.domain.announcement.domain.repository;
 
+import com.startingblock.domain.announcement.domain.Announcement;
 import com.startingblock.domain.announcement.dto.AnnouncementDetailRes;
 import com.startingblock.domain.announcement.dto.AnnouncementRes;
 import org.springframework.data.domain.Pageable;
@@ -13,5 +14,6 @@ public interface AnnouncementQuerydslRepository {
     Slice<AnnouncementRes> findAnnouncements(Long userId, Pageable pageable, String businessAge, String region, String supportType, String sort, String search);
     AnnouncementDetailRes findAnnouncementDetail(Long userId, Long announcementId);
     List<AnnouncementRes> findThreeRandomAnnouncement(Long userId);
+    List<Announcement> findOffCampusAnnouncementsByRoadmapId(Long userId, Long roadmapId);
 
 }

--- a/src/main/java/com/startingblock/domain/announcement/domain/repository/AnnouncementQuerydslRepositoryImpl.java
+++ b/src/main/java/com/startingblock/domain/announcement/domain/repository/AnnouncementQuerydslRepositoryImpl.java
@@ -1,24 +1,26 @@
 package com.startingblock.domain.announcement.domain.repository;
 
+import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.startingblock.domain.announcement.dto.AnnouncementDetailRes;
-import com.startingblock.domain.announcement.dto.AnnouncementRes;
-import com.startingblock.domain.announcement.dto.QAnnouncementDetailRes;
-import com.startingblock.domain.announcement.dto.QAnnouncementRes;
+import com.startingblock.domain.announcement.domain.Announcement;
+import com.startingblock.domain.announcement.dto.*;
 import com.startingblock.domain.common.Status;
+import com.startingblock.domain.roadmap.domain.QRoadmap;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 
 import static com.startingblock.domain.announcement.domain.QAnnouncement.*;
+import static com.startingblock.domain.roadmap.domain.QRoadmap.*;
 import static com.startingblock.domain.roadmap.domain.QRoadmapAnnouncement.*;
 
 @RequiredArgsConstructor
@@ -124,6 +126,20 @@ public class AnnouncementQuerydslRepositoryImpl implements AnnouncementQuerydslR
         List<AnnouncementRes> announcements = hasNext ? announcementResList.subList(0, pageable.getPageSize()) : announcementResList;
 
         return new SliceImpl<>(announcements, pageable, hasNext);
+    }
+
+    @Override
+    public List<Announcement> findOffCampusAnnouncementsByRoadmapId(Long userId, Long roadmapId) {
+        return queryFactory
+                .select(announcement)
+                .from(roadmap)
+                .leftJoin(roadmapAnnouncement).on(roadmap.id.eq(roadmapAnnouncement.roadmap.id))
+                .leftJoin(announcement).on(roadmapAnnouncement.announcement.id.eq(announcement.id))
+                .where(
+                        roadmap.id.eq(roadmapId),
+                        roadmap.user.id.eq(userId)
+                )
+                .fetch();
     }
 
     private BooleanExpression businessAgeExpression(final String businessAge) {

--- a/src/main/java/com/startingblock/domain/announcement/domain/repository/AnnouncementRepository.java
+++ b/src/main/java/com/startingblock/domain/announcement/domain/repository/AnnouncementRepository.java
@@ -3,5 +3,7 @@ package com.startingblock.domain.announcement.domain.repository;
 import com.startingblock.domain.announcement.domain.Announcement;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface AnnouncementRepository extends JpaRepository<Announcement, Long> , AnnouncementQuerydslRepository {
 }

--- a/src/main/java/com/startingblock/domain/announcement/dto/RoadmapAnnouncementRes.java
+++ b/src/main/java/com/startingblock/domain/announcement/dto/RoadmapAnnouncementRes.java
@@ -1,0 +1,43 @@
+package com.startingblock.domain.announcement.dto;
+
+import com.startingblock.domain.announcement.domain.Announcement;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@Builder
+public class RoadmapAnnouncementRes {
+
+    private Long announcementId;
+    private String department;
+    private String title;
+    private String dDay;
+    private Boolean isBookmarked;
+
+    public static List<RoadmapAnnouncementRes> of(final List<Announcement> announcements) {
+        return announcements.stream()
+                .map(announcement -> RoadmapAnnouncementRes.builder()
+                        .announcementId(announcement.getId())
+                        .department(announcement.getBizPrchDprtNm())
+                        .title(announcement.getTitle())
+                        .dDay(announcement.getEndDate() == null ? announcement.getNonDate() : String.valueOf(ChronoUnit.DAYS.between(LocalDateTime.now(), announcement.getEndDate())))
+                        .isBookmarked(true)
+                        .build())
+                .sorted(Comparator.comparing(roadmapAnnouncementRes -> {
+                    try {
+                        return Integer.parseInt(roadmapAnnouncementRes.getDDay());
+                    } catch (NumberFormatException e) {
+                        return Integer.MAX_VALUE;
+                    }
+                }))
+                .toList();
+    }
+
+}

--- a/src/main/java/com/startingblock/domain/roadmap/application/RoadmapService.java
+++ b/src/main/java/com/startingblock/domain/roadmap/application/RoadmapService.java
@@ -1,5 +1,7 @@
 package com.startingblock.domain.roadmap.application;
 
+import com.startingblock.domain.announcement.dto.AnnouncementRes;
+import com.startingblock.domain.announcement.dto.RoadmapAnnouncementRes;
 import com.startingblock.domain.roadmap.dto.AnnouncementSavedRoadmapRes;
 import com.startingblock.domain.roadmap.dto.RoadmapDetailRes;
 import com.startingblock.domain.roadmap.dto.RoadmapRegisterReq;
@@ -21,5 +23,6 @@ public interface RoadmapService {
     List<RoadmapDetailRes> swapRoadmap(UserPrincipal userPrincipal, SwapRoadmapReq swapRoadmapReq);
     List<RoadmapDetailRes> leapCurrentRoadmap(UserPrincipal userPrincipal);
     List<RoadmapDetailRes> addRoadmap(UserPrincipal userPrincipal, String roadmapTitle);
+    List<RoadmapAnnouncementRes> findOffCampusAnnouncementsOfRoadmap(UserPrincipal userPrincipal, Long roadmapId);
 
 }

--- a/src/main/java/com/startingblock/domain/roadmap/application/RoadmapServiceImpl.java
+++ b/src/main/java/com/startingblock/domain/roadmap/application/RoadmapServiceImpl.java
@@ -2,6 +2,8 @@ package com.startingblock.domain.roadmap.application;
 
 import com.startingblock.domain.announcement.domain.Announcement;
 import com.startingblock.domain.announcement.domain.repository.AnnouncementRepository;
+import com.startingblock.domain.announcement.dto.AnnouncementRes;
+import com.startingblock.domain.announcement.dto.RoadmapAnnouncementRes;
 import com.startingblock.domain.announcement.exception.InvalidAnnouncementException;
 import com.startingblock.domain.roadmap.domain.Roadmap;
 import com.startingblock.domain.roadmap.domain.RoadmapAnnouncement;
@@ -236,6 +238,13 @@ public class RoadmapServiceImpl implements RoadmapService {
         roadmaps.add(newRoadmap);
 
         return RoadmapDetailRes.toRoadmapDetailResList(roadmaps);
+    }
+
+    @Override
+    public List<RoadmapAnnouncementRes> findOffCampusAnnouncementsOfRoadmap(final UserPrincipal userPrincipal, final Long roadmapId) {
+        List<Announcement> announcements = announcementRepository.findOffCampusAnnouncementsByRoadmapId(userPrincipal.getId(), roadmapId);
+
+        return RoadmapAnnouncementRes.of(announcements);
     }
 
 }

--- a/src/main/java/com/startingblock/domain/roadmap/presentation/RoadmapController.java
+++ b/src/main/java/com/startingblock/domain/roadmap/presentation/RoadmapController.java
@@ -1,5 +1,7 @@
 package com.startingblock.domain.roadmap.presentation;
 
+import com.startingblock.domain.announcement.dto.AnnouncementRes;
+import com.startingblock.domain.announcement.dto.RoadmapAnnouncementRes;
 import com.startingblock.domain.roadmap.application.RoadmapService;
 import com.startingblock.domain.roadmap.dto.AnnouncementSavedRoadmapRes;
 import com.startingblock.domain.roadmap.dto.RoadmapDetailRes;
@@ -40,6 +42,19 @@ public class RoadmapController {
             @Parameter(name = "Authorization Token") @CurrentUser final UserPrincipal userPrincipal
     ) {
         return ResponseEntity.ok(roadmapService.findRoadmaps(userPrincipal));
+    }
+
+    @Operation(summary = "로드맵의 공고 리스트 조회(교외 사업)", description = "로드맵의 공고 리스트 조회(교외 사업)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "로드맵의 공고 리스트 조회(교외 사업) 성공", content = {@Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = RoadmapAnnouncementRes.class)))}),
+            @ApiResponse(responseCode = "400", description = "로드맵의 공고 리스트 조회(교외 사업) 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})
+    })
+    @GetMapping("/{roadmap-id}/off-campus")
+    public ResponseEntity<List<RoadmapAnnouncementRes>> findAnnouncementsOfRoadmap(
+            @Parameter(name = "Authorization Token") @CurrentUser final UserPrincipal userPrincipal,
+            @PathVariable(name = "roadmap-id") final Long roadmapId
+    ) {
+        return ResponseEntity.ok(roadmapService.findOffCampusAnnouncementsOfRoadmap(userPrincipal, roadmapId));
     }
 
     @Operation(summary = "공고가 저장된 로드맵 조회", description = "공고가 저장된 로드맵 조회")


### PR DESCRIPTION
* feat: RoadmapStatus 추가

* feat: 로드맵 삭제 API 구현

* feat: 로드맵에 해당 공고가 저장 여부 리스트 조회 API 구현

* feat: 로드맵 순서 변경 API 구현

* feat: 로드맵 현재 단계 도약 API 구현

* feat: 로드맵 단계 추가 API 구현

* chore: swagger 수정

* feat: 로드맵 id로 공고 리스트 조회 API 구현

* fix: 로드맵 교외사업 조회 API 구현

* refactor: Method Naming 변경

- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.`
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?
## 작업 내용

## 스크린샷

## 주의사항

Closes #{이슈 번호}