### PR TITLE
feat: 교내 로드맵 / 공고 관련 API 구현 (#85)

### DIFF
--- a/src/main/java/com/startingblock/domain/announcement/application/AnnouncementService.java
+++ b/src/main/java/com/startingblock/domain/announcement/application/AnnouncementService.java
@@ -1,8 +1,7 @@
 package com.startingblock.domain.announcement.application;
 
-import com.startingblock.domain.announcement.dto.AnnouncementDetailRes;
-import com.startingblock.domain.announcement.dto.AnnouncementRes;
-import com.startingblock.domain.announcement.dto.CustomAnnouncementRes;
+import com.startingblock.domain.announcement.domain.Keyword;
+import com.startingblock.domain.announcement.dto.*;
 import com.startingblock.global.config.security.token.UserPrincipal;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -19,4 +18,8 @@ public interface AnnouncementService {
     List<AnnouncementRes> findThreeRandomAnnouncement(UserPrincipal userPrincipal);
     void uploadAnnouncementsFile(UserPrincipal userPrincipal);
     List<CustomAnnouncementRes> findCustomAnnouncement(UserPrincipal userPrincipal);
+    List<SystemRes> findSystems(UserPrincipal userPrincipal);
+    List<OnCampusAnnouncementRes> findOnCampusAnnouncements(UserPrincipal userPrincipal, Keyword keyword);
+    List<LectureRes> findLectures(UserPrincipal userPrincipal);
+
 }

--- a/src/main/java/com/startingblock/domain/announcement/application/AnnouncementServiceImpl.java
+++ b/src/main/java/com/startingblock/domain/announcement/application/AnnouncementServiceImpl.java
@@ -2,11 +2,10 @@ package com.startingblock.domain.announcement.application;
 
 import com.startingblock.domain.announcement.domain.Announcement;
 import com.startingblock.domain.announcement.domain.AnnouncementType;
+import com.startingblock.domain.announcement.domain.Keyword;
 import com.startingblock.domain.announcement.domain.University;
 import com.startingblock.domain.announcement.domain.repository.AnnouncementRepository;
-import com.startingblock.domain.announcement.dto.AnnouncementDetailRes;
-import com.startingblock.domain.announcement.dto.AnnouncementRes;
-import com.startingblock.domain.announcement.dto.CustomAnnouncementRes;
+import com.startingblock.domain.announcement.dto.*;
 import com.startingblock.domain.announcement.exception.InvalidAnnouncementException;
 import com.startingblock.domain.announcement.exception.PermissionDeniedException;
 import com.startingblock.domain.user.domain.Role;
@@ -23,12 +22,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.http.MediaType;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestClient;
 
 import java.time.Duration;
 import java.time.LocalDate;
@@ -200,7 +196,7 @@ public class AnnouncementServiceImpl implements AnnouncementService {
     }
 
     @Override
-    public AnnouncementDetailRes findAnnouncementDetailById(UserPrincipal userPrincipal, Long announcementId) {
+    public AnnouncementDetailRes findAnnouncementDetailById(final UserPrincipal userPrincipal, final Long announcementId) {
         AnnouncementDetailRes announcementDetail = announcementRepository.findAnnouncementDetail(userPrincipal.getId(), announcementId);
 
         if (announcementDetail == null)
@@ -210,12 +206,12 @@ public class AnnouncementServiceImpl implements AnnouncementService {
     }
 
     @Override
-    public List<AnnouncementRes> findThreeRandomAnnouncement(UserPrincipal userPrincipal) {
+    public List<AnnouncementRes> findThreeRandomAnnouncement(final UserPrincipal userPrincipal) {
         return announcementRepository.findThreeRandomAnnouncement(userPrincipal.getId());
     }
 
     @Override
-    public List<CustomAnnouncementRes> findCustomAnnouncement(UserPrincipal userPrincipal) {
+    public List<CustomAnnouncementRes> findCustomAnnouncement(final UserPrincipal userPrincipal) {
         User user = userRepository.findById(userPrincipal.getId())
                 .orElseThrow(InvalidUserException::new);
         University university = CampusFindService.findUserUniversity(user);
@@ -255,5 +251,35 @@ public class AnnouncementServiceImpl implements AnnouncementService {
                     .build());
         }
         return response;
+    }
+
+    @Override
+    public List<SystemRes> findSystems(final UserPrincipal userPrincipal) {
+        User user = userRepository.findById(userPrincipal.getId())
+                .orElseThrow(InvalidUserException::new);
+
+        University university = University.of(user.getUniversity());
+
+        return announcementRepository.findSystems(user.getId(), university);
+    }
+
+    @Override
+    public List<OnCampusAnnouncementRes> findOnCampusAnnouncements(final UserPrincipal userPrincipal, final Keyword keyword) {
+        User user = userRepository.findById(userPrincipal.getId())
+                .orElseThrow(InvalidUserException::new);
+
+        University university = University.of(user.getUniversity());
+
+        return announcementRepository.findOnCampusAnnouncements(userPrincipal.getId(), university, keyword);
+    }
+
+    @Override
+    public List<LectureRes> findLectures(UserPrincipal userPrincipal) {
+        User user = userRepository.findById(userPrincipal.getId())
+                .orElseThrow(InvalidUserException::new);
+
+        University university = University.of(user.getUniversity());
+
+        return announcementRepository.findLectures(userPrincipal.getId(), university);
     }
 }

--- a/src/main/java/com/startingblock/domain/announcement/domain/Keyword.java
+++ b/src/main/java/com/startingblock/domain/announcement/domain/Keyword.java
@@ -1,5 +1,30 @@
 package com.startingblock.domain.announcement.domain;
 
+import lombok.Getter;
+
+@Getter
 public enum Keyword {
-    CLUB, CAMP, CONTEST, LECTURE, MENTORING, ETC, SPACE
+    CLUB("동아리"),
+    CAMP("캠프"),
+    CONTEST("경진대회"),
+    LECTURE("특강"),
+    MENTORING("멘토링"),
+    ETC("기타"),
+    SPACE("공간");
+
+    private final String keyword;
+
+    Keyword(String keyword) {
+        this.keyword = keyword;
+    }
+
+    public static Keyword of(String keyword) {
+        for (Keyword value : values()) {
+            if (value.getKeyword().equals(keyword)) {
+                return value;
+            }
+        }
+        return ETC;
+    }
+
 }

--- a/src/main/java/com/startingblock/domain/announcement/domain/Lecture.java
+++ b/src/main/java/com/startingblock/domain/announcement/domain/Lecture.java
@@ -32,6 +32,12 @@ public class Lecture extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private University university;
 
+    private Integer roadmapCount;
+
+    public void addRoadmapCount() {
+        this.roadmapCount++;
+    }
+
     @Builder
     public Lecture(String title, String liberal, Integer credit, String session, String instructor, String content, University university) {
         this.title = title;
@@ -41,6 +47,7 @@ public class Lecture extends BaseEntity {
         this.instructor = instructor;
         this.content = content;
         this.university = university;
+        this.roadmapCount = 0;
     }
 
 }

--- a/src/main/java/com/startingblock/domain/announcement/domain/University.java
+++ b/src/main/java/com/startingblock/domain/announcement/domain/University.java
@@ -1,42 +1,61 @@
 package com.startingblock.domain.announcement.domain;
 
+import lombok.Getter;
+
+@Getter
 public enum University {
-    EWHA,
-    HAN_YANG,
-    HUFS,
-    KON_KUK,
-    KOREA,
-    KYUNG_HEE,
-    SEOUL_TECH,
-    SEOUL,
-    SUNG_KYUN_KWAN,
-    YON_SEI,
-    CATHOLIC,
-    GANGSEO,
-    KYONGGI,
-    KWANGWOON,
-    KOOKMIN,
-    DUKSUNG,
-    DONGGUK,
-    DONGDUK,
-    MYONGJI,
-    SAHMYOOK,
-    SANGMYUNG,
-    SOGANG,
-    SEOKYEONG,
-    SEOUL_EDUCATION,
-    UOS,
-    SEOUL_WOMAN,
-    HANYOUNG,
-    SUNGKONGHOE,
-    SUNGSHIN,
-    SEJONG,
-    SOOKMYUNG,
-    SOONGSIL,
-    CHUNG_ANG,
-    CHONGSHIN,
-    CHUGYE,
-    KNSU,
-    HANSUNG,
-    HONGIK
+    EWHA("이화여자대학교"),
+    HAN_YANG("한양대학교"),
+    HUFS("한국외국어대학교"),
+    KON_KUK("건국대학교"),
+    KOREA("고려대학교"),
+    KYUNG_HEE("경희대학교"),
+    SEOUL_TECH("서울과학기술대학교"),
+    SEOUL("서울대학교"),
+    SUNG_KYUN_KWAN("성균관대학교"),
+    YON_SEI("연세대학교"),
+    CATHOLIC("가톨릭대학교"),
+    GANGSEO("강서대학교"),
+    KYONGGI("경기대학교"),
+    KWANGWOON("광운대학교"),
+    KOOKMIN("국민대학교"),
+    DUKSUNG("덕성여자대학교"),
+    DONGGUK("동국대학교"),
+    DONGDUK("동덕여자대학교"),
+    MYONGJI("명지대학교"),
+    SAHMYOOK("삼육대학교"),
+    SANGMYUNG("상명대학교"),
+    SOGANG("서강대학교"),
+    SEOKYEONG("서경대학교"),
+    SEOUL_EDUCATION("서울교육대학교"),
+    UOS("서울시립대학교"),
+    SEOUL_WOMAN("서울여자대학교"),
+    HANYOUNG("한영대학교"),
+    SUNGKONGHOE("성공회대학교"),
+    SUNGSHIN("성신여자대학교"),
+    SEJONG("세종대학교"),
+    SOOKMYUNG("숙명여자대학교"),
+    SOONGSIL("숭실대학교"),
+    CHUNG_ANG("중앙대학교"),
+    CHONGSHIN("총신대학교"),
+    CHUGYE("추계예술대학교"),
+    KNSU("한국교원대학교"),
+    HANSUNG("한성대학교"),
+    HONGIK("홍익대학교");
+
+    private final String name;
+
+    University(String name) {
+        this.name = name;
+    }
+
+    public static University of(String name) {
+        for (University uni : University.values()) {
+            if (uni.name.equals(name)) {
+                return uni;
+            }
+        }
+        return null;
+    }
+
 }

--- a/src/main/java/com/startingblock/domain/announcement/domain/repository/AnnouncementQuerydslRepository.java
+++ b/src/main/java/com/startingblock/domain/announcement/domain/repository/AnnouncementQuerydslRepository.java
@@ -1,9 +1,9 @@
 package com.startingblock.domain.announcement.domain.repository;
 
 import com.startingblock.domain.announcement.domain.Announcement;
+import com.startingblock.domain.announcement.domain.Keyword;
 import com.startingblock.domain.announcement.domain.University;
-import com.startingblock.domain.announcement.dto.AnnouncementDetailRes;
-import com.startingblock.domain.announcement.dto.AnnouncementRes;
+import com.startingblock.domain.announcement.dto.*;
 import com.startingblock.domain.user.domain.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -19,4 +19,8 @@ public interface AnnouncementQuerydslRepository {
     List<Announcement> findListOfRoadmapByRoadmapId(Long userId, Long roadmapId, String type);
     List<Announcement> findCustomAnnouncementOnOff(User user, University university);
     List<Announcement> findCustomAnnouncementOff(User user);
+    List<OnCampusAnnouncementRes> findOnCampusAnnouncements(Long userId, University university, Keyword keyword);
+    List<SystemRes> findSystems(Long userId, University university);
+    List<LectureRes> findLectures(Long id, University university);
+
 }

--- a/src/main/java/com/startingblock/domain/announcement/domain/repository/AnnouncementRepository.java
+++ b/src/main/java/com/startingblock/domain/announcement/domain/repository/AnnouncementRepository.java
@@ -2,6 +2,8 @@ package com.startingblock.domain.announcement.domain.repository;
 
 import com.startingblock.domain.announcement.domain.Announcement;
 import com.startingblock.domain.announcement.domain.AnnouncementType;
+import com.startingblock.domain.announcement.domain.Keyword;
+import com.startingblock.domain.announcement.domain.University;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -12,4 +14,7 @@ public interface AnnouncementRepository extends JpaRepository<Announcement, Long
     List<Announcement> findAnnouncementsByAnnouncementTypeAndIsFileUploaded(AnnouncementType announcementType, boolean isFileUsed);
 
     List<Announcement> findByAnnouncementType(AnnouncementType announcementType);
+    List<Announcement> findByAnnouncementTypeAndUniversity(AnnouncementType announcementType, University university);
+    List<Announcement> findByAnnouncementTypeAndUniversityAndKeyword(AnnouncementType announcementType, University university, Keyword keyword);
+
 }

--- a/src/main/java/com/startingblock/domain/announcement/domain/repository/LectureQuerydslRepository.java
+++ b/src/main/java/com/startingblock/domain/announcement/domain/repository/LectureQuerydslRepository.java
@@ -1,0 +1,11 @@
+package com.startingblock.domain.announcement.domain.repository;
+
+import com.startingblock.domain.announcement.domain.Lecture;
+
+import java.util.List;
+
+public interface LectureQuerydslRepository {
+
+    List<Lecture> findLecturesOfRoadmapsByRoadmapId(Long userId, Long roadmapId);
+
+}

--- a/src/main/java/com/startingblock/domain/announcement/domain/repository/LectureQuerydslRepositoryImpl.java
+++ b/src/main/java/com/startingblock/domain/announcement/domain/repository/LectureQuerydslRepositoryImpl.java
@@ -1,0 +1,35 @@
+package com.startingblock.domain.announcement.domain.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.startingblock.domain.announcement.domain.Lecture;
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.startingblock.domain.announcement.domain.QLecture.*;
+import static com.startingblock.domain.roadmap.domain.QRoadmap.*;
+import static com.startingblock.domain.roadmap.domain.QRoadmapLecture.*;
+
+@RequiredArgsConstructor
+public class LectureQuerydslRepositoryImpl implements LectureQuerydslRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Lecture> findLecturesOfRoadmapsByRoadmapId(Long userId, Long roadmapId) {
+        return queryFactory
+                .select(lecture)
+                .from(roadmap)
+                .leftJoin(roadmapLecture).on(roadmap.id.eq(roadmapLecture.roadmap.id))
+                .leftJoin(lecture).on(roadmapLecture.lecture.id.eq(lecture.id))
+                .where(
+                        roadmap.id.eq(roadmapId),
+                        roadmap.user.id.eq(userId)
+                )
+                .fetch();
+    }
+
+
+
+}

--- a/src/main/java/com/startingblock/domain/announcement/domain/repository/LectureRepository.java
+++ b/src/main/java/com/startingblock/domain/announcement/domain/repository/LectureRepository.java
@@ -1,0 +1,7 @@
+package com.startingblock.domain.announcement.domain.repository;
+
+import com.startingblock.domain.announcement.domain.Lecture;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LectureRepository extends JpaRepository<Lecture, Long>, LectureQuerydslRepository {
+}

--- a/src/main/java/com/startingblock/domain/announcement/dto/LectureRes.java
+++ b/src/main/java/com/startingblock/domain/announcement/dto/LectureRes.java
@@ -1,0 +1,30 @@
+package com.startingblock.domain.announcement.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Data;
+
+@Data
+public class LectureRes {
+
+    private Long lectureId;
+    private String title;
+    private String liberal;
+    private Integer credit;
+    private String session;
+    private String instructor;
+    private String content;
+    private Boolean isBookmarked;
+
+    @QueryProjection
+    public LectureRes(Long lectureId, String title, String liberal, Integer credit, String session, String instructor, String content, Boolean isBookmarked) {
+        this.lectureId = lectureId;
+        this.title = title;
+        this.liberal = liberal;
+        this.credit = credit;
+        this.session = session;
+        this.instructor = instructor;
+        this.content = content;
+        this.isBookmarked = isBookmarked;
+    }
+
+}

--- a/src/main/java/com/startingblock/domain/announcement/dto/OnCampusAnnouncementRes.java
+++ b/src/main/java/com/startingblock/domain/announcement/dto/OnCampusAnnouncementRes.java
@@ -1,0 +1,28 @@
+package com.startingblock.domain.announcement.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import com.startingblock.domain.announcement.domain.Announcement;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class OnCampusAnnouncementRes {
+
+    private Long announcementId;
+    private String title;
+    private String content;
+    private Boolean isBookmarked;
+
+    @Builder
+    @QueryProjection
+    public OnCampusAnnouncementRes(Long announcementId, String title, String content, Boolean isBookmarked) {
+        this.announcementId = announcementId;
+        this.title = title;
+        this.content = content;
+        this.isBookmarked = isBookmarked;
+    }
+
+}

--- a/src/main/java/com/startingblock/domain/announcement/dto/RoadmapAnnouncementRes.java
+++ b/src/main/java/com/startingblock/domain/announcement/dto/RoadmapAnnouncementRes.java
@@ -21,11 +21,30 @@ public class RoadmapAnnouncementRes {
     private String dDay;
     private Boolean isBookmarked;
 
-    public static List<RoadmapAnnouncementRes> of(final List<Announcement> announcements) {
+    public static List<RoadmapAnnouncementRes> toOffCampusDto(final List<Announcement> announcements) {
         return announcements.stream()
                 .map(announcement -> RoadmapAnnouncementRes.builder()
                         .announcementId(announcement.getId())
                         .department(announcement.getBizPrchDprtNm())
+                        .title(announcement.getTitle())
+                        .dDay(announcement.getEndDate() == null ? announcement.getNonDate() : String.valueOf(ChronoUnit.DAYS.between(LocalDateTime.now(), announcement.getEndDate())))
+                        .isBookmarked(true)
+                        .build())
+                .sorted(Comparator.comparing(roadmapAnnouncementRes -> {
+                    try {
+                        return Integer.parseInt(roadmapAnnouncementRes.getDDay());
+                    } catch (NumberFormatException e) {
+                        return Integer.MAX_VALUE;
+                    }
+                }))
+                .toList();
+    }
+
+    public static List<RoadmapAnnouncementRes> toOnCampusDto(final List<Announcement> announcements) {
+        return announcements.stream()
+                .map(announcement -> RoadmapAnnouncementRes.builder()
+                        .announcementId(announcement.getId())
+                        .department(announcement.getKeyword().toString())
                         .title(announcement.getTitle())
                         .dDay(announcement.getEndDate() == null ? announcement.getNonDate() : String.valueOf(ChronoUnit.DAYS.between(LocalDateTime.now(), announcement.getEndDate())))
                         .isBookmarked(true)

--- a/src/main/java/com/startingblock/domain/announcement/dto/RoadmapLectureRes.java
+++ b/src/main/java/com/startingblock/domain/announcement/dto/RoadmapLectureRes.java
@@ -1,0 +1,37 @@
+package com.startingblock.domain.announcement.dto;
+
+import com.startingblock.domain.announcement.domain.Lecture;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@Builder
+public class RoadmapLectureRes {
+
+    private String title;
+    private String liberal;
+    private Integer credit;
+    private String session;
+    private String instructor;
+    private String content;
+    private Boolean isBookmarked;
+
+    public static List<RoadmapLectureRes> toDto(final List<Lecture> lectures) {
+        return lectures.stream()
+                .map(lecture -> RoadmapLectureRes.builder()
+                        .title(lecture.getTitle())
+                        .liberal(lecture.getLiberal())
+                        .credit(lecture.getCredit())
+                        .session(lecture.getSession())
+                        .instructor(lecture.getInstructor())
+                        .content(lecture.getContent())
+                        .isBookmarked(true)
+                        .build())
+                .toList();
+    }
+
+}

--- a/src/main/java/com/startingblock/domain/announcement/dto/RoadmapSystemRes.java
+++ b/src/main/java/com/startingblock/domain/announcement/dto/RoadmapSystemRes.java
@@ -1,0 +1,36 @@
+package com.startingblock.domain.announcement.dto;
+
+import com.startingblock.domain.announcement.domain.Announcement;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@Builder
+public class RoadmapSystemRes {
+
+    private Long announcementId;
+    private String title;
+    private String target;
+    private String content;
+    private Boolean isBookmarked;
+
+    public static List<RoadmapSystemRes> toDto(final List<Announcement> announcements) {
+        return announcements.stream()
+                .map(announcement -> RoadmapSystemRes.builder()
+                        .announcementId(announcement.getId())
+                        .target(announcement.getPostTarget())
+                        .title(announcement.getTitle())
+                        .content(announcement.getContent())
+                        .isBookmarked(true)
+                        .build())
+                .toList();
+    }
+
+}

--- a/src/main/java/com/startingblock/domain/announcement/dto/SystemRes.java
+++ b/src/main/java/com/startingblock/domain/announcement/dto/SystemRes.java
@@ -1,0 +1,25 @@
+package com.startingblock.domain.announcement.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Data;
+
+
+@Data
+public class SystemRes {
+
+    private Long systemId;
+    private String title;
+    private String target;
+    private String content;
+    private Boolean isBookmarked;
+
+    @QueryProjection
+    public SystemRes(Long systemId, String title, String target, String content, Boolean isBookmarked) {
+        this.systemId = systemId;
+        this.title = title;
+        this.target = target;
+        this.content = content;
+        this.isBookmarked = isBookmarked;
+    }
+
+}

--- a/src/main/java/com/startingblock/domain/announcement/exception/InvalidLectureException.java
+++ b/src/main/java/com/startingblock/domain/announcement/exception/InvalidLectureException.java
@@ -1,0 +1,9 @@
+package com.startingblock.domain.announcement.exception;
+
+public class InvalidLectureException extends RuntimeException {
+
+        public InvalidLectureException() {
+            super("유효하지 않는 강의 ID 입니다.");
+        }
+
+}

--- a/src/main/java/com/startingblock/domain/announcement/presentation/AnnouncementController.java
+++ b/src/main/java/com/startingblock/domain/announcement/presentation/AnnouncementController.java
@@ -2,9 +2,8 @@ package com.startingblock.domain.announcement.presentation;
 
 
 import com.startingblock.domain.announcement.application.AnnouncementService;
-import com.startingblock.domain.announcement.dto.AnnouncementDetailRes;
-import com.startingblock.domain.announcement.dto.AnnouncementRes;
-import com.startingblock.domain.announcement.dto.CustomAnnouncementRes;
+import com.startingblock.domain.announcement.domain.Keyword;
+import com.startingblock.domain.announcement.dto.*;
 import com.startingblock.global.config.security.token.CurrentUser;
 import com.startingblock.global.config.security.token.UserPrincipal;
 import com.startingblock.global.payload.ErrorResponse;
@@ -46,10 +45,10 @@ public class AnnouncementController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "공고 조건별 검색(Paging)", description = "공고 조건별 검색(Paging)")
+    @Operation(summary = "교외 공고 조건별 검색(Paging)", description = "교외 공고 조건별 검색(Paging)")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "공고 조건별 검색 성공", content = {@Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = AnnouncementRes.class)))}),
-            @ApiResponse(responseCode = "400", description = "공고 조건별 검색 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})
+            @ApiResponse(responseCode = "200", description = "교외 공고 조건별 검색 성공", content = {@Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = AnnouncementRes.class)))}),
+            @ApiResponse(responseCode = "400", description = "교외 공고 조건별 검색 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})
     })
     @GetMapping("/list")
     public ResponseEntity<Slice<AnnouncementRes>> findAnnouncements(
@@ -62,6 +61,43 @@ public class AnnouncementController {
             @Parameter(name = "search", description = "검색어") @RequestParam(required = false) final String search
     ) {
         return ResponseEntity.ok(announcementService.findAnnouncements(userPrincipal, pageable, postTarget, region, supportType, sorting, search));
+    }
+
+    @Operation(summary = "교내 학사 제도 검색", description = "교내 학사 제도 검색")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "교내 학사 제도 검색 성공", content = {@Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = SystemRes.class)))}),
+            @ApiResponse(responseCode = "400", description = "교내 학사 제도 검색 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})
+    })
+    @GetMapping("/list/system")
+    public ResponseEntity<List<SystemRes>> findSystems(
+            @Parameter(name = "Authorization Token") @CurrentUser final UserPrincipal userPrincipal
+    ) {
+        return ResponseEntity.ok(announcementService.findSystems(userPrincipal));
+    }
+
+    @Operation(summary = "교내 지원 공고 검색", description = "교내 지원 공고 검색")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "교내 지원 공고 검색 성공", content = {@Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = OnCampusAnnouncementRes.class)))}),
+            @ApiResponse(responseCode = "400", description = "교내 지원 공고 검색 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})
+    })
+    @GetMapping("/list/on-campus")
+    public ResponseEntity<List<OnCampusAnnouncementRes>> findOnCampusAnnouncements(
+            @Parameter(name = "Authorization Token") @CurrentUser final UserPrincipal userPrincipal,
+            @Parameter(name = "keyword", description = "키워드(CLUB/CAMP/CONTEST/LECTURE/MENTORING/ETC/SPACE)") @RequestParam(required = false) final Keyword keyword
+    ) {
+        return ResponseEntity.ok(announcementService.findOnCampusAnnouncements(userPrincipal, keyword));
+    }
+
+    @Operation(summary = "교내 창업 강의 검색", description = "교내 창업 강의 검색")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "교내 창업 강의 검색 성공", content = {@Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = LectureRes.class)))}),
+            @ApiResponse(responseCode = "400", description = "교내 창업 강의 검색 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})
+    })
+    @GetMapping("/list/lecture")
+    public ResponseEntity<List<LectureRes>> findLectures(
+            @Parameter(name = "Authorization Token") @CurrentUser final UserPrincipal userPrincipal
+    ) {
+        return ResponseEntity.ok(announcementService.findLectures(userPrincipal));
     }
 
     @Operation(summary = "공고 상세정보 조회", description = "공고 상세정보 조회")
@@ -113,4 +149,5 @@ public class AnnouncementController {
     ) {
         return ResponseEntity.ok(announcementService.findCustomAnnouncement(userPrincipal));
     }
+
 }

--- a/src/main/java/com/startingblock/domain/roadmap/application/RoadmapService.java
+++ b/src/main/java/com/startingblock/domain/roadmap/application/RoadmapService.java
@@ -1,6 +1,6 @@
 package com.startingblock.domain.roadmap.application;
 
-import com.startingblock.domain.announcement.dto.RoadmapAnnouncementRes;
+import com.startingblock.domain.announcement.dto.RoadmapLectureRes;
 import com.startingblock.domain.roadmap.dto.AnnouncementSavedRoadmapRes;
 import com.startingblock.domain.roadmap.dto.RoadmapDetailRes;
 import com.startingblock.domain.roadmap.dto.RoadmapRegisterReq;
@@ -22,6 +22,8 @@ public interface RoadmapService {
     List<RoadmapDetailRes> swapRoadmap(UserPrincipal userPrincipal, SwapRoadmapReq swapRoadmapReq);
     List<RoadmapDetailRes> leapCurrentRoadmap(UserPrincipal userPrincipal);
     List<RoadmapDetailRes> addRoadmap(UserPrincipal userPrincipal, String roadmapTitle);
-    List<RoadmapAnnouncementRes> findListOfRoadmap(UserPrincipal userPrincipal, Long roadmapId, String type);
+    List<?> findListOfRoadmap(UserPrincipal userPrincipal, Long roadmapId, String type);
+    void addRoadmapLecture(UserPrincipal userPrincipal, Long roadmapId, Long lectureId);
+    List<RoadmapLectureRes> findLecturesOfRoadmap(UserPrincipal userPrincipal, Long roadmapId);
 
 }

--- a/src/main/java/com/startingblock/domain/roadmap/application/RoadmapServiceImpl.java
+++ b/src/main/java/com/startingblock/domain/roadmap/application/RoadmapServiceImpl.java
@@ -1,13 +1,20 @@
 package com.startingblock.domain.roadmap.application;
 
 import com.startingblock.domain.announcement.domain.Announcement;
+import com.startingblock.domain.announcement.domain.Lecture;
 import com.startingblock.domain.announcement.domain.repository.AnnouncementRepository;
+import com.startingblock.domain.announcement.domain.repository.LectureRepository;
+import com.startingblock.domain.announcement.dto.RoadmapLectureRes;
 import com.startingblock.domain.announcement.dto.RoadmapAnnouncementRes;
+import com.startingblock.domain.announcement.dto.RoadmapSystemRes;
 import com.startingblock.domain.announcement.exception.InvalidAnnouncementException;
+import com.startingblock.domain.announcement.exception.InvalidLectureException;
 import com.startingblock.domain.roadmap.domain.Roadmap;
 import com.startingblock.domain.roadmap.domain.RoadmapAnnouncement;
+import com.startingblock.domain.roadmap.domain.RoadmapLecture;
 import com.startingblock.domain.roadmap.domain.RoadmapStatus;
 import com.startingblock.domain.roadmap.domain.repository.RoadmapAnnouncementRepository;
+import com.startingblock.domain.roadmap.domain.repository.RoadmapLectureRepository;
 import com.startingblock.domain.roadmap.domain.repository.RoadmapRepository;
 import com.startingblock.domain.roadmap.dto.AnnouncementSavedRoadmapRes;
 import com.startingblock.domain.roadmap.dto.RoadmapDetailRes;
@@ -38,6 +45,8 @@ public class RoadmapServiceImpl implements RoadmapService {
     private final RoadmapRepository roadmapRepository;
     private final AnnouncementRepository announcementRepository;
     private final RoadmapAnnouncementRepository roadmapAnnouncementRepository;
+    private final LectureRepository lectureRepository;
+    private final RoadmapLectureRepository roadmapLectureRepository;
 
     @Override
     @Transactional
@@ -239,10 +248,46 @@ public class RoadmapServiceImpl implements RoadmapService {
     }
 
     @Override
-    public List<RoadmapAnnouncementRes> findListOfRoadmap(final UserPrincipal userPrincipal, final Long roadmapId, final String type) {
+    public List<?> findListOfRoadmap(final UserPrincipal userPrincipal, final Long roadmapId, final String type) {
         List<Announcement> announcements = announcementRepository.findListOfRoadmapByRoadmapId(userPrincipal.getId(), roadmapId, type);
 
-        return RoadmapAnnouncementRes.of(announcements);
+        if(type.equals("OFF-CAMPUS"))
+            return RoadmapAnnouncementRes.toOffCampusDto(announcements);
+        else if(type.equals("ON-CAMPUS"))
+            return RoadmapAnnouncementRes.toOnCampusDto(announcements);
+        else
+            return RoadmapSystemRes.toDto(announcements);
+    }
+
+    @Override
+    @Transactional
+    public void addRoadmapLecture(UserPrincipal userPrincipal, Long roadmapId, Long lectureId) {
+        Roadmap roadmap = roadmapRepository.findRoadmapById(roadmapId)
+                .orElseThrow(InvalidRoadmapException::new);
+
+        if (!Objects.equals(roadmap.getUser().getId(), userPrincipal.getId()))
+            throw new RoadmapMismatchUserException();
+
+        Lecture lecture = lectureRepository.findById(lectureId)
+                .orElseThrow(InvalidLectureException::new);
+
+        if (roadmapLectureRepository.existsByRoadmapIdAndLectureId(roadmapId, lectureId))
+            throw new AlreadyExistsRoadmapException();
+
+        RoadmapLecture roadmapLecture = RoadmapLecture.builder()
+                .roadmap(roadmap)
+                .lecture(lecture)
+                .build();
+
+        lecture.addRoadmapCount();
+        roadmapLectureRepository.save(roadmapLecture);
+    }
+
+    @Override
+    public List<RoadmapLectureRes> findLecturesOfRoadmap(UserPrincipal userPrincipal, Long roadmapId) {
+        List<Lecture> lectures = lectureRepository.findLecturesOfRoadmapsByRoadmapId(userPrincipal.getId(), roadmapId);
+
+        return RoadmapLectureRes.toDto(lectures);
     }
 
 }

--- a/src/main/java/com/startingblock/domain/roadmap/domain/RoadmapLecture.java
+++ b/src/main/java/com/startingblock/domain/roadmap/domain/RoadmapLecture.java
@@ -1,6 +1,7 @@
 package com.startingblock.domain.roadmap.domain;
 
 import com.startingblock.domain.announcement.domain.Announcement;
+import com.startingblock.domain.announcement.domain.Lecture;
 import com.startingblock.domain.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -9,12 +10,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "roadmap_announcement")
+@Table(name = "roadmap_lecture")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class RoadmapAnnouncement extends BaseEntity {
+public class RoadmapLecture extends BaseEntity {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -22,13 +24,13 @@ public class RoadmapAnnouncement extends BaseEntity {
     private Roadmap roadmap;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "announcement_id", nullable = false)
-    private Announcement announcement;
+    @JoinColumn(name = "lecture_id", nullable = false)
+    private Lecture lecture;
 
     @Builder
-    public RoadmapAnnouncement(Roadmap roadmap, Announcement announcement) {
+    public RoadmapLecture(Roadmap roadmap, Lecture lecture) {
         this.roadmap = roadmap;
-        this.announcement = announcement;
+        this.lecture = lecture;
     }
 
 }

--- a/src/main/java/com/startingblock/domain/roadmap/domain/repository/RoadmapLectureRepository.java
+++ b/src/main/java/com/startingblock/domain/roadmap/domain/repository/RoadmapLectureRepository.java
@@ -1,0 +1,22 @@
+package com.startingblock.domain.roadmap.domain.repository;
+
+import com.startingblock.domain.announcement.domain.Lecture;
+import com.startingblock.domain.roadmap.domain.Roadmap;
+import com.startingblock.domain.roadmap.domain.RoadmapLecture;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface RoadmapLectureRepository extends JpaRepository<RoadmapLecture, Long> {
+
+    boolean existsByRoadmapIdAndLectureId(Long roadmapId, Long lectureId);
+
+    Optional<RoadmapLecture> findByRoadmapAndLecture(Roadmap roadmap, Lecture lecture);
+
+    @Modifying
+    @Query("delete from RoadmapLecture rl where rl.roadmap.id = :roadmapId")
+    void bulkDeleteByLectureId(Long roadmapId);
+
+}

--- a/src/main/java/com/startingblock/domain/roadmap/presentation/RoadmapController.java
+++ b/src/main/java/com/startingblock/domain/roadmap/presentation/RoadmapController.java
@@ -1,5 +1,6 @@
 package com.startingblock.domain.roadmap.presentation;
 
+import com.startingblock.domain.announcement.dto.RoadmapLectureRes;
 import com.startingblock.domain.announcement.dto.RoadmapAnnouncementRes;
 import com.startingblock.domain.roadmap.application.RoadmapService;
 import com.startingblock.domain.roadmap.dto.AnnouncementSavedRoadmapRes;
@@ -49,12 +50,25 @@ public class RoadmapController {
             @ApiResponse(responseCode = "400", description = "로드맵의 공고 리스트 조회(교외, 교내, 창업제도) 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})
     })
     @GetMapping("/{roadmap-id}/list")
-    public ResponseEntity<List<RoadmapAnnouncementRes>> findAnnouncementsOfRoadmap(
+    public ResponseEntity<List<?>> findAnnouncementsOfRoadmap(
             @Parameter(name = "Authorization Token") @CurrentUser final UserPrincipal userPrincipal,
             @Parameter(name = "type", description = "공고 타입(OFF-CAMPUS, ON-CAMPUS, SYSTEM)") @RequestParam(name = "type") final String type,
             @PathVariable(name = "roadmap-id") final Long roadmapId
     ) {
         return ResponseEntity.ok(roadmapService.findListOfRoadmap(userPrincipal, roadmapId, type));
+    }
+
+    @Operation(summary = "로드맵의 창업 강의 리스트 조회", description = "로드맵의 창업 강의 리스트 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "로드맵의 창업 강의 리스트 조회 성공", content = {@Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = RoadmapLectureRes.class)))}),
+            @ApiResponse(responseCode = "400", description = "로드맵의 창업 강의 리스트 조회 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})
+    })
+    @GetMapping("/{roadmap-id}/list/lecture")
+    public ResponseEntity<List<RoadmapLectureRes>> findLectureOfRoadmap(
+            @Parameter(name = "Authorization Token") @CurrentUser final UserPrincipal userPrincipal,
+            @PathVariable(name = "roadmap-id") final Long roadmapId
+    ) {
+        return ResponseEntity.ok(roadmapService.findLecturesOfRoadmap(userPrincipal, roadmapId));
     }
 
     @Operation(summary = "공고가 저장된 로드맵 조회", description = "공고가 저장된 로드맵 조회")
@@ -150,10 +164,25 @@ public class RoadmapController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "로드맵의 공고 삭제", description = "로드맵의 공고 삭제")
+    @Operation(summary = "로드맵에 강의 저장(창업 강의)", description = "로드맵에 강의 저장(창업 강의) 저장")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "로드맵의 공고 삭제 성공", content = {@Content(mediaType = "application/json")}),
-            @ApiResponse(responseCode = "400", description = "로드맵의 공고 삭제 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})
+            @ApiResponse(responseCode = "200", description = "로드맵에 강의 저장(창업 강의) 저장 성공", content = {@Content(mediaType = "application/json")}),
+            @ApiResponse(responseCode = "400", description = "로드맵에 강의 저장(창업 강의) 저장 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})
+    })
+    @PostMapping("/{roadmap-id}/lecture")
+    public ResponseEntity<Void> addRoadmapLecture(
+            @Parameter(name = "Authorization Token") @CurrentUser final UserPrincipal userPrincipal,
+            @Parameter(name = "roadmap-id", description = "로드맵 ID") @PathVariable(name = "roadmap-id") final Long roadmapId,
+            @Parameter(name = "lectureId", description = "창업강의 ID") @RequestParam(name = "lectureId") final Long lectureId
+    ) {
+        roadmapService.addRoadmapLecture(userPrincipal, roadmapId, lectureId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "로드맵의 공고(교외, 교내, 창업제도) 삭제", description = "로드맵의 공고(교외, 교내, 창업제도) 삭제")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "로드맵의 공고(교외, 교내, 창업제도) 삭제 성공", content = {@Content(mediaType = "application/json")}),
+            @ApiResponse(responseCode = "400", description = "로드맵의 공고(교외, 교내, 창업제도) 삭제 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})
     })
     @DeleteMapping("/{roadmap-id}/announcement")
     public ResponseEntity<Void> deleteRoadmapAnnouncement(


### PR DESCRIPTION
* feat: 교내, 교외, 창업제도 로드맵 리스트  API 구현

* feat: 교내, 교외, 창업제도 로드맵 리스트 조회 API 구현

* feat: 창업 강의 로드맵 추가 API 구현

* feat: 로드맵의 창업 강의 리스트 조회 API 구현

* feat: 창업 제도 리스트 API 구현

* feat: 교내 공고 리스트 조회 API 구현

* feat: 교내 창업 제도 공고 리스트 조회 API 구현

* feat: 교내 창업 강의 리스트 조회 API 구현

- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.`
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?
## 작업 내용

## 스크린샷

## 주의사항

Closes #{이슈 번호}