### PR TITLE
feat: 로드맵 / 공고 관련 API 수정 및 추가 (#90)

### DIFF
--- a/src/main/java/com/startingblock/domain/announcement/application/AnnouncementService.java
+++ b/src/main/java/com/startingblock/domain/announcement/application/AnnouncementService.java
@@ -21,5 +21,7 @@ public interface AnnouncementService {
     List<SystemRes> findSystems(UserPrincipal userPrincipal);
     List<OnCampusAnnouncementRes> findOnCampusAnnouncements(UserPrincipal userPrincipal, Keyword keyword);
     List<LectureRes> findLectures(UserPrincipal userPrincipal);
+    List<SupportGroupRes> findSupportGroups(UserPrincipal userPrincipal, Keyword keyword);
+    List<String> findSupportGroupKeywords(UserPrincipal userPrincipal);
 
 }

--- a/src/main/java/com/startingblock/domain/announcement/application/AnnouncementServiceImpl.java
+++ b/src/main/java/com/startingblock/domain/announcement/application/AnnouncementServiceImpl.java
@@ -274,7 +274,7 @@ public class AnnouncementServiceImpl implements AnnouncementService {
     }
 
     @Override
-    public List<LectureRes> findLectures(UserPrincipal userPrincipal) {
+    public List<LectureRes> findLectures(final UserPrincipal userPrincipal) {
         User user = userRepository.findById(userPrincipal.getId())
                 .orElseThrow(InvalidUserException::new);
 
@@ -282,4 +282,26 @@ public class AnnouncementServiceImpl implements AnnouncementService {
 
         return announcementRepository.findLectures(userPrincipal.getId(), university);
     }
+
+    @Override
+    public List<SupportGroupRes> findSupportGroups(final UserPrincipal userPrincipal, final Keyword keyword) {
+        User user = userRepository.findById(userPrincipal.getId())
+                .orElseThrow(InvalidUserException::new);
+
+        University university = University.of(user.getUniversity());
+
+        List<Announcement> supportGroups = announcementRepository.findSupportGroups(userPrincipal.getId(), university, keyword);
+        return SupportGroupRes.toDto(supportGroups);
+    }
+
+    @Override
+    public List<String> findSupportGroupKeywords(UserPrincipal userPrincipal) {
+        User user = userRepository.findById(userPrincipal.getId())
+                .orElseThrow(InvalidUserException::new);
+
+        University university = University.of(user.getUniversity());
+
+        return announcementRepository.findSupportGroupKeywords(university);
+    }
+
 }

--- a/src/main/java/com/startingblock/domain/announcement/domain/AnnouncementType.java
+++ b/src/main/java/com/startingblock/domain/announcement/domain/AnnouncementType.java
@@ -1,5 +1,5 @@
 package com.startingblock.domain.announcement.domain;
 
 public enum AnnouncementType {
-    OPEN_DATA, BIZ_INFO, ON_CAMPUS, SYSTEM
+    OPEN_DATA, BIZ_INFO, ON_CAMPUS, SYSTEM, SUPPORT_GROUP
 }

--- a/src/main/java/com/startingblock/domain/announcement/domain/Lecture.java
+++ b/src/main/java/com/startingblock/domain/announcement/domain/Lecture.java
@@ -38,6 +38,10 @@ public class Lecture extends BaseEntity {
         this.roadmapCount++;
     }
 
+    public void subtractRoadmapCount() {
+        this.roadmapCount--;
+    }
+
     @Builder
     public Lecture(String title, String liberal, Integer credit, String session, String instructor, String content, University university) {
         this.title = title;

--- a/src/main/java/com/startingblock/domain/announcement/domain/repository/AnnouncementQuerydslRepository.java
+++ b/src/main/java/com/startingblock/domain/announcement/domain/repository/AnnouncementQuerydslRepository.java
@@ -22,5 +22,7 @@ public interface AnnouncementQuerydslRepository {
     List<OnCampusAnnouncementRes> findOnCampusAnnouncements(Long userId, University university, Keyword keyword);
     List<SystemRes> findSystems(Long userId, University university);
     List<LectureRes> findLectures(Long id, University university);
+    List<Announcement> findSupportGroups(Long id, University university, Keyword keyword);
+    List<String> findSupportGroupKeywords(University university);
 
 }

--- a/src/main/java/com/startingblock/domain/announcement/domain/repository/AnnouncementQuerydslRepositoryImpl.java
+++ b/src/main/java/com/startingblock/domain/announcement/domain/repository/AnnouncementQuerydslRepositoryImpl.java
@@ -9,7 +9,6 @@ import com.startingblock.domain.announcement.domain.*;
 import com.startingblock.domain.announcement.dto.*;
 import com.startingblock.domain.common.Status;
 import com.startingblock.domain.roadmap.domain.QRoadmap;
-import com.startingblock.domain.roadmap.domain.QRoadmapLecture;
 import com.startingblock.domain.roadmap.domain.RoadmapStatus;
 import com.startingblock.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +16,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
@@ -162,8 +162,10 @@ public class AnnouncementQuerydslRepositoryImpl implements AnnouncementQuerydslR
                 .select(
                     new QOnCampusAnnouncementRes(
                             announcement.id,
+                            announcement.keyword.stringValue(),
                             announcement.title,
-                            announcement.content,
+                            announcement.insertDate,
+                            announcement.detailUrl,
                             roadmapAnnouncement.announcement.id.isNotNull()
                     )
                 )
@@ -219,6 +221,32 @@ public class AnnouncementQuerydslRepositoryImpl implements AnnouncementQuerydslR
                 .leftJoin(roadmapLecture).on(roadmapLecture.lecture.eq(lecture).and(roadmapLecture.roadmap.user.id.eq(id)))
                 .where(
                         lecture.university.eq(university)
+                )
+                .distinct()
+                .fetch();
+    }
+
+    @Override
+    public List<Announcement> findSupportGroups(final Long id, final University university, final Keyword keyword) {
+        return queryFactory
+                .selectFrom(announcement)
+                .where(
+                        announcement.announcementType.eq(AnnouncementType.SUPPORT_GROUP),
+                        announcement.university.eq(university),
+                        keywordExpression(keyword)
+                )
+                .distinct()
+                .fetch();
+    }
+
+    @Override
+    public List<String> findSupportGroupKeywords(University university) {
+        return queryFactory
+                .select(announcement.keyword.stringValue())
+                .from(announcement)
+                .where(
+                        announcement.announcementType.eq(AnnouncementType.SUPPORT_GROUP),
+                        announcement.university.eq(university)
                 )
                 .distinct()
                 .fetch();

--- a/src/main/java/com/startingblock/domain/announcement/domain/repository/AnnouncementRepository.java
+++ b/src/main/java/com/startingblock/domain/announcement/domain/repository/AnnouncementRepository.java
@@ -4,6 +4,7 @@ import com.startingblock.domain.announcement.domain.Announcement;
 import com.startingblock.domain.announcement.domain.AnnouncementType;
 import com.startingblock.domain.announcement.domain.Keyword;
 import com.startingblock.domain.announcement.domain.University;
+import com.startingblock.domain.announcement.dto.SupportGroupRes;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -14,7 +15,5 @@ public interface AnnouncementRepository extends JpaRepository<Announcement, Long
     List<Announcement> findAnnouncementsByAnnouncementTypeAndIsFileUploaded(AnnouncementType announcementType, boolean isFileUsed);
 
     List<Announcement> findByAnnouncementType(AnnouncementType announcementType);
-    List<Announcement> findByAnnouncementTypeAndUniversity(AnnouncementType announcementType, University university);
-    List<Announcement> findByAnnouncementTypeAndUniversityAndKeyword(AnnouncementType announcementType, University university, Keyword keyword);
 
 }

--- a/src/main/java/com/startingblock/domain/announcement/dto/OnCampusAnnouncementRes.java
+++ b/src/main/java/com/startingblock/domain/announcement/dto/OnCampusAnnouncementRes.java
@@ -2,26 +2,33 @@ package com.startingblock.domain.announcement.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
 import com.startingblock.domain.announcement.domain.Announcement;
+import com.startingblock.domain.announcement.domain.Keyword;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Data
 public class OnCampusAnnouncementRes {
 
     private Long announcementId;
+    private String keyword;
     private String title;
-    private String content;
+    private LocalDateTime insertDate;
+    private String detailUrl;
     private Boolean isBookmarked;
 
     @Builder
     @QueryProjection
-    public OnCampusAnnouncementRes(Long announcementId, String title, String content, Boolean isBookmarked) {
+    public OnCampusAnnouncementRes(Long announcementId, String keyword, String title, LocalDateTime insertDate, String detailUrl, Boolean isBookmarked) {
         this.announcementId = announcementId;
+        this.keyword = keyword;
         this.title = title;
-        this.content = content;
+        this.insertDate = insertDate;
+        this.detailUrl = detailUrl;
         this.isBookmarked = isBookmarked;
     }
 

--- a/src/main/java/com/startingblock/domain/announcement/dto/SupportGroupRes.java
+++ b/src/main/java/com/startingblock/domain/announcement/dto/SupportGroupRes.java
@@ -1,0 +1,29 @@
+package com.startingblock.domain.announcement.dto;
+
+import com.startingblock.domain.announcement.domain.Announcement;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@Builder
+public class SupportGroupRes {
+
+    private Long announcementId;
+    private String title;
+    private String content;
+
+    public static List<SupportGroupRes> toDto(final List<Announcement> supportGroups) {
+        return supportGroups.stream()
+                .map(supportGroup -> SupportGroupRes.builder()
+                        .announcementId(supportGroup.getId())
+                        .title(supportGroup.getTitle())
+                        .content(supportGroup.getContent())
+                        .build())
+                .toList();
+    }
+
+}

--- a/src/main/java/com/startingblock/domain/announcement/presentation/AnnouncementController.java
+++ b/src/main/java/com/startingblock/domain/announcement/presentation/AnnouncementController.java
@@ -63,6 +63,33 @@ public class AnnouncementController {
         return ResponseEntity.ok(announcementService.findAnnouncements(userPrincipal, pageable, postTarget, region, supportType, sorting, search));
     }
 
+    @Operation(summary = "교내 창업지원단 검색", description = "교내 창업지원단 검색")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "교내 창업지원단 검색 성공", content = {@Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = SupportGroupRes.class)))}),
+            @ApiResponse(responseCode = "400", description = "교내 창업지원단 검색 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})
+    })
+    @GetMapping("/list/support-group")
+    public ResponseEntity<List<SupportGroupRes>> findSupportGroups(
+            @Parameter(name = "Authorization Token") @CurrentUser final UserPrincipal userPrincipal,
+            @Parameter(name = "keyword", description = "키워드(CLUB/CAMP/CONTEST/LECTURE/MENTORING/ETC/SPACE)") @RequestParam(required = false) final Keyword keyword
+
+    ) {
+        return ResponseEntity.ok(announcementService.findSupportGroups(userPrincipal, keyword));
+    }
+
+    @Operation(summary = "교내 창업지원단 키워드 조회", description = "교내 창업지원단 키워드 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "교내 창업지원단 키워드 조회 성공", content = {@Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = String.class)))}),
+            @ApiResponse(responseCode = "400", description = "교내 창업지원단 키워드 조회 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})
+    })
+    @GetMapping("/list/support-group/keyword")
+    public ResponseEntity<List<String>> findSupportGroupKeywords(
+            @Parameter(name = "Authorization Token") @CurrentUser final UserPrincipal userPrincipal
+
+    ) {
+        return ResponseEntity.ok(announcementService.findSupportGroupKeywords(userPrincipal));
+    }
+
     @Operation(summary = "교내 학사 제도 검색", description = "교내 학사 제도 검색")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "교내 학사 제도 검색 성공", content = {@Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = SystemRes.class)))}),

--- a/src/main/java/com/startingblock/domain/roadmap/application/RoadmapService.java
+++ b/src/main/java/com/startingblock/domain/roadmap/application/RoadmapService.java
@@ -1,7 +1,7 @@
 package com.startingblock.domain.roadmap.application;
 
 import com.startingblock.domain.announcement.dto.RoadmapLectureRes;
-import com.startingblock.domain.roadmap.dto.AnnouncementSavedRoadmapRes;
+import com.startingblock.domain.roadmap.dto.SavedRoadmapRes;
 import com.startingblock.domain.roadmap.dto.RoadmapDetailRes;
 import com.startingblock.domain.roadmap.dto.RoadmapRegisterReq;
 import com.startingblock.domain.roadmap.dto.SwapRoadmapReq;
@@ -18,12 +18,14 @@ public interface RoadmapService {
     void deleteRoadmapAnnouncement(UserPrincipal userPrincipal, Long roadmapId, Long announcementId);
     List<RoadmapDetailRes> findRoadmaps(UserPrincipal userPrincipal);
     List<RoadmapDetailRes> deleteRoadmap(UserPrincipal userPrincipal, Long roadmapId);
-    List<AnnouncementSavedRoadmapRes> findAnnouncementSavedRoadmap(UserPrincipal userPrincipal, Long announcementId);
+    List<SavedRoadmapRes> findAnnouncementSavedRoadmap(UserPrincipal userPrincipal, Long announcementId);
     List<RoadmapDetailRes> swapRoadmap(UserPrincipal userPrincipal, SwapRoadmapReq swapRoadmapReq);
     List<RoadmapDetailRes> leapCurrentRoadmap(UserPrincipal userPrincipal);
     List<RoadmapDetailRes> addRoadmap(UserPrincipal userPrincipal, String roadmapTitle);
     List<?> findListOfRoadmap(UserPrincipal userPrincipal, Long roadmapId, String type);
     void addRoadmapLecture(UserPrincipal userPrincipal, Long roadmapId, Long lectureId);
     List<RoadmapLectureRes> findLecturesOfRoadmap(UserPrincipal userPrincipal, Long roadmapId);
+    void deleteRoadmapLecture(UserPrincipal userPrincipal, Long roadmapId, Long lectureId);
+    List<SavedRoadmapRes> findLectureSavedRoadmap(UserPrincipal userPrincipal, Long lectureId);
 
 }

--- a/src/main/java/com/startingblock/domain/roadmap/domain/repository/RoadmapQuerydslRepository.java
+++ b/src/main/java/com/startingblock/domain/roadmap/domain/repository/RoadmapQuerydslRepository.java
@@ -1,7 +1,7 @@
 package com.startingblock.domain.roadmap.domain.repository;
 
 import com.startingblock.domain.roadmap.domain.Roadmap;
-import com.startingblock.domain.roadmap.dto.AnnouncementSavedRoadmapRes;
+import com.startingblock.domain.roadmap.dto.SavedRoadmapRes;
 import com.startingblock.domain.roadmap.dto.RoadmapDetailRes;
 
 import java.util.List;
@@ -10,6 +10,7 @@ public interface RoadmapQuerydslRepository {
 
     List<RoadmapDetailRes> findRoadmapDetailResponsesByUserId(Long userId);
     List<Roadmap> findRoadmapsByUserId(Long userId);
-    List<AnnouncementSavedRoadmapRes> findAnnouncementSavedRoadmap(Long announcementId, Long userId);
+    List<SavedRoadmapRes> findAnnouncementSavedRoadmap(Long announcementId, Long userId);
+    List<SavedRoadmapRes> findLectureSavedRoadmap(Long lectureId, Long id);
 
 }

--- a/src/main/java/com/startingblock/domain/roadmap/domain/repository/RoadmapQuerydslRepositoryImpl.java
+++ b/src/main/java/com/startingblock/domain/roadmap/domain/repository/RoadmapQuerydslRepositoryImpl.java
@@ -1,20 +1,19 @@
 package com.startingblock.domain.roadmap.domain.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.startingblock.domain.announcement.domain.QAnnouncement;
-import com.startingblock.domain.roadmap.domain.QRoadmapAnnouncement;
+import com.startingblock.domain.roadmap.domain.QRoadmapLecture;
 import com.startingblock.domain.roadmap.domain.Roadmap;
-import com.startingblock.domain.roadmap.dto.AnnouncementSavedRoadmapRes;
-import com.startingblock.domain.roadmap.dto.QAnnouncementSavedRoadmapRes;
+import com.startingblock.domain.roadmap.dto.QSavedRoadmapRes;
+import com.startingblock.domain.roadmap.dto.SavedRoadmapRes;
 import com.startingblock.domain.roadmap.dto.QRoadmapDetailRes;
 import com.startingblock.domain.roadmap.dto.RoadmapDetailRes;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
-import static com.startingblock.domain.announcement.domain.QAnnouncement.*;
 import static com.startingblock.domain.roadmap.domain.QRoadmap.*;
 import static com.startingblock.domain.roadmap.domain.QRoadmapAnnouncement.*;
+import static com.startingblock.domain.roadmap.domain.QRoadmapLecture.*;
 
 @RequiredArgsConstructor
 public class RoadmapQuerydslRepositoryImpl implements RoadmapQuerydslRepository {
@@ -48,10 +47,10 @@ public class RoadmapQuerydslRepositoryImpl implements RoadmapQuerydslRepository 
     }
 
     @Override
-    public List<AnnouncementSavedRoadmapRes> findAnnouncementSavedRoadmap(final Long announcementId, final Long userId) {
+    public List<SavedRoadmapRes> findAnnouncementSavedRoadmap(final Long announcementId, final Long userId) {
         return queryFactory
                 .select(
-                        new QAnnouncementSavedRoadmapRes(
+                        new QSavedRoadmapRes(
                                 roadmap.id,
                                 roadmap.title,
                                 roadmapAnnouncement.announcement.id.isNotNull()
@@ -63,6 +62,26 @@ public class RoadmapQuerydslRepositoryImpl implements RoadmapQuerydslRepository 
                         roadmapAnnouncement.announcement.id.eq(announcementId)
                 )
                 .where(roadmap.user.id.eq(userId))
+                .distinct()
+                .fetch();
+    }
+
+    @Override
+    public List<SavedRoadmapRes> findLectureSavedRoadmap(Long lectureId, Long id) {
+        return queryFactory
+                .select(
+                        new QSavedRoadmapRes(
+                                roadmap.id,
+                                roadmap.title,
+                                roadmapLecture.lecture.id.isNotNull()
+                        )
+                )
+                .from(roadmap)
+                .leftJoin(roadmapLecture).on(
+                        roadmapLecture.roadmap.id.eq(roadmap.id),
+                        roadmapLecture.lecture.id.eq(lectureId)
+                )
+                .where(roadmap.user.id.eq(id))
                 .distinct()
                 .fetch();
     }

--- a/src/main/java/com/startingblock/domain/roadmap/dto/RoadmapAnnouncementRes.java
+++ b/src/main/java/com/startingblock/domain/roadmap/dto/RoadmapAnnouncementRes.java
@@ -1,4 +1,4 @@
-package com.startingblock.domain.announcement.dto;
+package com.startingblock.domain.roadmap.dto;
 
 import com.startingblock.domain.announcement.domain.Announcement;
 import lombok.AllArgsConstructor;
@@ -21,30 +21,11 @@ public class RoadmapAnnouncementRes {
     private String dDay;
     private Boolean isBookmarked;
 
-    public static List<RoadmapAnnouncementRes> toOffCampusDto(final List<Announcement> announcements) {
+    public static List<RoadmapAnnouncementRes> toDto(final List<Announcement> announcements) {
         return announcements.stream()
                 .map(announcement -> RoadmapAnnouncementRes.builder()
                         .announcementId(announcement.getId())
                         .department(announcement.getBizPrchDprtNm())
-                        .title(announcement.getTitle())
-                        .dDay(announcement.getEndDate() == null ? announcement.getNonDate() : String.valueOf(ChronoUnit.DAYS.between(LocalDateTime.now(), announcement.getEndDate())))
-                        .isBookmarked(true)
-                        .build())
-                .sorted(Comparator.comparing(roadmapAnnouncementRes -> {
-                    try {
-                        return Integer.parseInt(roadmapAnnouncementRes.getDDay());
-                    } catch (NumberFormatException e) {
-                        return Integer.MAX_VALUE;
-                    }
-                }))
-                .toList();
-    }
-
-    public static List<RoadmapAnnouncementRes> toOnCampusDto(final List<Announcement> announcements) {
-        return announcements.stream()
-                .map(announcement -> RoadmapAnnouncementRes.builder()
-                        .announcementId(announcement.getId())
-                        .department(announcement.getKeyword().toString())
                         .title(announcement.getTitle())
                         .dDay(announcement.getEndDate() == null ? announcement.getNonDate() : String.valueOf(ChronoUnit.DAYS.between(LocalDateTime.now(), announcement.getEndDate())))
                         .isBookmarked(true)

--- a/src/main/java/com/startingblock/domain/roadmap/dto/RoadmapOnCampusRes.java
+++ b/src/main/java/com/startingblock/domain/roadmap/dto/RoadmapOnCampusRes.java
@@ -1,0 +1,36 @@
+package com.startingblock.domain.roadmap.dto;
+
+import com.startingblock.domain.announcement.domain.Announcement;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@Builder
+public class RoadmapOnCampusRes {
+
+    private Long announcementId;
+    private String keyword;
+    private String title;
+    private LocalDate insertDate;
+    private String detailUrl;
+    private Boolean isBookmarked;
+
+    public static List<RoadmapOnCampusRes> toDto(final List<Announcement> announcements) {
+        return announcements.stream()
+                .map(announcement -> RoadmapOnCampusRes.builder()
+                        .announcementId(announcement.getId())
+                        .keyword(announcement.getKeyword().getKeyword())
+                        .title(announcement.getTitle())
+                        .insertDate(announcement.getInsertDate().toLocalDate())
+                        .detailUrl(announcement.getDetailUrl())
+                        .isBookmarked(true)
+                        .build())
+                .toList();
+    }
+
+}

--- a/src/main/java/com/startingblock/domain/roadmap/dto/SavedRoadmapRes.java
+++ b/src/main/java/com/startingblock/domain/roadmap/dto/SavedRoadmapRes.java
@@ -4,14 +4,14 @@ import com.querydsl.core.annotations.QueryProjection;
 import lombok.Data;
 
 @Data
-public class AnnouncementSavedRoadmapRes {
+public class SavedRoadmapRes {
 
     private Long roadmapId;
     private String title;
     private Boolean isAnnouncementSaved;
 
     @QueryProjection
-    public AnnouncementSavedRoadmapRes(Long roadmapId, String title, Boolean isAnnouncementSaved) {
+    public SavedRoadmapRes(Long roadmapId, String title, Boolean isAnnouncementSaved) {
         this.roadmapId = roadmapId;
         this.title = title;
         this.isAnnouncementSaved = isAnnouncementSaved;

--- a/src/main/java/com/startingblock/domain/roadmap/presentation/RoadmapController.java
+++ b/src/main/java/com/startingblock/domain/roadmap/presentation/RoadmapController.java
@@ -1,9 +1,9 @@
 package com.startingblock.domain.roadmap.presentation;
 
 import com.startingblock.domain.announcement.dto.RoadmapLectureRes;
-import com.startingblock.domain.announcement.dto.RoadmapAnnouncementRes;
+import com.startingblock.domain.roadmap.dto.RoadmapAnnouncementRes;
 import com.startingblock.domain.roadmap.application.RoadmapService;
-import com.startingblock.domain.roadmap.dto.AnnouncementSavedRoadmapRes;
+import com.startingblock.domain.roadmap.dto.SavedRoadmapRes;
 import com.startingblock.domain.roadmap.dto.RoadmapDetailRes;
 import com.startingblock.domain.roadmap.dto.RoadmapRegisterReq;
 import com.startingblock.domain.roadmap.dto.SwapRoadmapReq;
@@ -73,15 +73,28 @@ public class RoadmapController {
 
     @Operation(summary = "공고가 저장된 로드맵 조회", description = "공고가 저장된 로드맵 조회")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "공고가 저장된 로드맵 조회 성공", content = {@Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = AnnouncementSavedRoadmapRes.class)))}),
+            @ApiResponse(responseCode = "200", description = "공고가 저장된 로드맵 조회 성공", content = {@Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = SavedRoadmapRes.class)))}),
             @ApiResponse(responseCode = "400", description = "공고가 저장된 로드맵 조회 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})
     })
     @GetMapping("/announcement/{announcement-id}")
-    public ResponseEntity<List<AnnouncementSavedRoadmapRes>> findAnnouncementSavedRoadmap(
+    public ResponseEntity<List<SavedRoadmapRes>> findAnnouncementSavedRoadmap(
             @Parameter(name = "Authorization Token") @CurrentUser final UserPrincipal userPrincipal,
             @Parameter(name = "announcementId", description = "공고 ID") @PathVariable(name = "announcement-id") final Long announcementId
     ) {
         return ResponseEntity.ok(roadmapService.findAnnouncementSavedRoadmap(userPrincipal, announcementId));
+    }
+
+    @Operation(summary = "강의가 저장된 로드맵 조회", description = "강의가 저장된 로드맵 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "강의가 저장된 로드맵 조회 성공", content = {@Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = SavedRoadmapRes.class)))}),
+            @ApiResponse(responseCode = "400", description = "강의가 저장된 로드맵 조회 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})
+    })
+    @GetMapping("/lecture/{lecture-id}")
+    public ResponseEntity<List<SavedRoadmapRes>> findLectureSavedRoadmap(
+            @Parameter(name = "Authorization Token") @CurrentUser final UserPrincipal userPrincipal,
+            @Parameter(name = "lectureId", description = "강의 ID") @PathVariable(name = "lecture-id") final Long lectureId
+    ) {
+        return ResponseEntity.ok(roadmapService.findLectureSavedRoadmap(userPrincipal, lectureId));
     }
 
     @Operation(summary = "로드맵 초기 등록", description = "로드맵 초기 등록")
@@ -191,6 +204,21 @@ public class RoadmapController {
             @Parameter(name = "announcementId", description = "공고 ID") @RequestParam(name = "announcementId") final Long announcementId
     ) {
         roadmapService.deleteRoadmapAnnouncement(userPrincipal, roadmapId, announcementId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "로드맵의 강의(창업 강의) 삭제", description = "로드맵의 강의(창업 강의) 삭제")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "로드맵의 강의(창업 강의) 삭제 성공", content = {@Content(mediaType = "application/json")}),
+            @ApiResponse(responseCode = "400", description = "로드맵의 강의(창업 강의) 삭제 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})
+    })
+    @DeleteMapping("/{roadmap-id}/lecture")
+    public ResponseEntity<Void> deleteRoadmapLecture(
+            @Parameter(name = "Authorization Token") @CurrentUser final UserPrincipal userPrincipal,
+            @Parameter(name = "roadmap-id", description = "로드맵 ID") @PathVariable(name = "roadmap-id") final Long roadmapId,
+            @Parameter(name = "lectureId", description = "강의 ID") @RequestParam(name = "lectureId") final Long lectureId
+    ) {
+        roadmapService.deleteRoadmapLecture(userPrincipal, roadmapId, lectureId);
         return ResponseEntity.noContent().build();
     }
 


### PR DESCRIPTION
* feat: 창업지원단 공고 리스트 조회 API 구현

* feat: 교내 지원 공고 리스트 조회 API 구현

* feat: 교내 창업지원단 키워드 조회 API 구현

* feat: 로드맵 교내사업 Response 스팩 수정

* feat: 교내 공고 Response detailUrl 컬럼 추가

* feat: 창업 강의 로드맵 삭제 API 구현

* feat: 해당 창업 강의가 어떤 로드맵에 저장되어 있는지 여부 조회 API 구현

- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.`
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?
## 작업 내용

## 스크린샷

## 주의사항

Closes #{이슈 번호}