### PR TITLE
feat: 요구사항 반영 (#94)

### DIFF
--- a/src/main/java/com/startingblock/domain/announcement/domain/repository/AnnouncementQuerydslRepository.java
+++ b/src/main/java/com/startingblock/domain/announcement/domain/repository/AnnouncementQuerydslRepository.java
@@ -29,5 +29,6 @@ public interface AnnouncementQuerydslRepository {
     List<Announcement> findOffCampusAnnouncementsBySupportType(String supportType);
     List<Announcement> findOffCampusAnnouncementsByRoadmapCount();
     List<Announcement> findOffCampusAnnouncementsByInsertDate();
+    RoadmapSystemRes findRandomSystemByUniversity(Long id, University university);
 
 }

--- a/src/main/java/com/startingblock/domain/announcement/domain/repository/AnnouncementQuerydslRepositoryImpl.java
+++ b/src/main/java/com/startingblock/domain/announcement/domain/repository/AnnouncementQuerydslRepositoryImpl.java
@@ -389,6 +389,30 @@ public class AnnouncementQuerydslRepositoryImpl implements AnnouncementQuerydslR
                 .fetch();
     }
 
+    @Override
+    public RoadmapSystemRes findRandomSystemByUniversity(Long id, University university) {
+        return queryFactory
+                .select(
+                        new QRoadmapSystemRes(
+                                announcement.id,
+                                announcement.title,
+                                announcement.postTarget,
+                                announcement.content,
+                                roadmapAnnouncement.announcement.id.isNotNull()
+                        )
+                )
+                .from(announcement)
+                .leftJoin(roadmapAnnouncement).on(roadmapAnnouncement.announcement.eq(announcement).and(roadmapAnnouncement.roadmap.user.id.eq(id)))
+                .where(
+                        announcement.announcementType.eq(AnnouncementType.SYSTEM),
+                        announcement.university.eq(university)
+                )
+                .distinct()
+                .orderBy(Expressions.numberTemplate(Double.class, "function('rand')").asc())
+                .limit(1)
+                .fetchOne();
+    }
+
     private BooleanExpression keywordExpression(final Keyword keyword) {
         if (keyword == null) return null;
         return announcement.keyword.eq(keyword);

--- a/src/main/java/com/startingblock/domain/announcement/domain/repository/LectureQuerydslRepository.java
+++ b/src/main/java/com/startingblock/domain/announcement/domain/repository/LectureQuerydslRepository.java
@@ -1,11 +1,14 @@
 package com.startingblock.domain.announcement.domain.repository;
 
 import com.startingblock.domain.announcement.domain.Lecture;
+import com.startingblock.domain.announcement.domain.University;
+import com.startingblock.domain.announcement.dto.RecommendLectureRes;
 
 import java.util.List;
 
 public interface LectureQuerydslRepository {
 
     List<Lecture> findLecturesOfRoadmapsByRoadmapId(Long userId, Long roadmapId);
+    RecommendLectureRes findRandomLectureByUniversity(Long userId, University university);
 
 }

--- a/src/main/java/com/startingblock/domain/announcement/domain/repository/LectureQuerydslRepositoryImpl.java
+++ b/src/main/java/com/startingblock/domain/announcement/domain/repository/LectureQuerydslRepositoryImpl.java
@@ -1,8 +1,12 @@
 package com.startingblock.domain.announcement.domain.repository;
 
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.startingblock.domain.announcement.domain.Lecture;
 
+import com.startingblock.domain.announcement.domain.University;
+import com.startingblock.domain.announcement.dto.QRecommendLectureRes;
+import com.startingblock.domain.announcement.dto.RecommendLectureRes;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
@@ -29,6 +33,33 @@ public class LectureQuerydslRepositoryImpl implements LectureQuerydslRepository 
                         lecture.id.isNotNull()
                 )
                 .fetch();
+    }
+
+    @Override
+    public RecommendLectureRes findRandomLectureByUniversity(final Long userId, final University university) {
+        return queryFactory
+                .select(
+                        new QRecommendLectureRes(
+                                lecture.id,
+                                roadmapLecture.lecture.id.isNotNull(),
+                                lecture.title,
+                                lecture.liberal,
+                                lecture.credit,
+                                lecture.session,
+                                lecture.instructor,
+                                lecture.content
+                        )
+                )
+                .from(lecture)
+                .leftJoin(roadmapLecture).on(lecture.id.eq(roadmapLecture.lecture.id).and(roadmapLecture.roadmap.user.id.eq(userId)))
+                .where(
+                        lecture.university.eq(university),
+                        lecture.id.isNotNull()
+                )
+                .distinct()
+                .orderBy(Expressions.numberTemplate(Double.class, "function('rand')").asc())
+                .limit(1)
+                .fetchOne();
     }
 
 }

--- a/src/main/java/com/startingblock/domain/announcement/dto/RecommendLectureRes.java
+++ b/src/main/java/com/startingblock/domain/announcement/dto/RecommendLectureRes.java
@@ -1,0 +1,32 @@
+package com.startingblock.domain.announcement.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+public class RecommendLectureRes {
+
+    private Long lectureId;
+    private Boolean isBookmarked;
+    private String title;
+    private String liberal;
+    private Integer credit;
+    private String session;
+    private String instructor;
+    private String content;
+
+    @Builder
+    @QueryProjection
+    public RecommendLectureRes(Long lectureId, Boolean isBookmarked, String title, String liberal, Integer credit, String session, String instructor, String content) {
+        this.lectureId = lectureId;
+        this.isBookmarked = isBookmarked;
+        this.title = title;
+        this.liberal = liberal;
+        this.credit = credit;
+        this.session = session;
+        this.instructor = instructor;
+        this.content = content;
+    }
+
+}

--- a/src/main/java/com/startingblock/domain/announcement/dto/RoadmapSystemRes.java
+++ b/src/main/java/com/startingblock/domain/announcement/dto/RoadmapSystemRes.java
@@ -1,18 +1,14 @@
 package com.startingblock.domain.announcement.dto;
 
+import com.querydsl.core.annotations.QueryProjection;
 import com.startingblock.domain.announcement.domain.Announcement;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
-import java.util.Comparator;
 import java.util.List;
 
 @Data
-@AllArgsConstructor
-@Builder
 public class RoadmapSystemRes {
 
     private Long announcementId;
@@ -31,6 +27,16 @@ public class RoadmapSystemRes {
                         .isBookmarked(true)
                         .build())
                 .toList();
+    }
+
+    @Builder
+    @QueryProjection
+    public RoadmapSystemRes(Long announcementId, String title, String target, String content, Boolean isBookmarked) {
+        this.announcementId = announcementId;
+        this.title = title;
+        this.target = target;
+        this.content = content;
+        this.isBookmarked = isBookmarked;
     }
 
 }

--- a/src/main/java/com/startingblock/domain/roadmap/application/RoadmapService.java
+++ b/src/main/java/com/startingblock/domain/roadmap/application/RoadmapService.java
@@ -1,8 +1,6 @@
 package com.startingblock.domain.roadmap.application;
 
-import com.startingblock.domain.announcement.dto.AnnouncementRes;
-import com.startingblock.domain.announcement.dto.RecommendAnnouncementRes;
-import com.startingblock.domain.announcement.dto.RoadmapLectureRes;
+import com.startingblock.domain.announcement.dto.*;
 import com.startingblock.domain.roadmap.dto.SavedRoadmapRes;
 import com.startingblock.domain.roadmap.dto.RoadmapDetailRes;
 import com.startingblock.domain.roadmap.dto.RoadmapRegisterReq;
@@ -31,5 +29,7 @@ public interface RoadmapService {
     List<SavedRoadmapRes> findLectureSavedRoadmap(UserPrincipal userPrincipal, Long lectureId);
     List<RecommendAnnouncementRes> recommendOffCampusAnnouncements(UserPrincipal userPrincipal, Long roadmapId);
     List<RecommendAnnouncementRes> recommendOnCampusAnnouncements(UserPrincipal userPrincipal, Long roadmapId);
+    RecommendLectureRes recommendLecture(UserPrincipal userPrincipal, Long roadmapId);
+    RoadmapSystemRes recommendSystem(UserPrincipal userPrincipal, Long roadmapId);
 
 }

--- a/src/main/java/com/startingblock/domain/roadmap/application/RoadmapServiceImpl.java
+++ b/src/main/java/com/startingblock/domain/roadmap/application/RoadmapServiceImpl.java
@@ -5,11 +5,8 @@ import com.startingblock.domain.announcement.domain.Lecture;
 import com.startingblock.domain.announcement.domain.University;
 import com.startingblock.domain.announcement.domain.repository.AnnouncementRepository;
 import com.startingblock.domain.announcement.domain.repository.LectureRepository;
-import com.startingblock.domain.announcement.dto.AnnouncementRes;
-import com.startingblock.domain.announcement.dto.RecommendAnnouncementRes;
-import com.startingblock.domain.announcement.dto.RoadmapLectureRes;
+import com.startingblock.domain.announcement.dto.*;
 import com.startingblock.domain.roadmap.dto.*;
-import com.startingblock.domain.announcement.dto.RoadmapSystemRes;
 import com.startingblock.domain.announcement.exception.InvalidAnnouncementException;
 import com.startingblock.domain.announcement.exception.InvalidLectureException;
 import com.startingblock.domain.roadmap.domain.Roadmap;
@@ -368,6 +365,52 @@ public class RoadmapServiceImpl implements RoadmapService {
 
         List<Announcement> recommendAnnouncements = announcementRepository.findThreeRandomOnCampusAnnouncements(university);
         return RecommendAnnouncementRes.toDto(recommendAnnouncements);
+    }
+
+    @Override
+    public RecommendLectureRes recommendLecture(final UserPrincipal userPrincipal, final Long roadmapId) {
+        User user = userRepository.findById(userPrincipal.getId())
+                .orElseThrow(InvalidUserException::new);
+
+        Roadmap roadmap = roadmapRepository.findById(roadmapId)
+                .orElseThrow(InvalidRoadmapException::new);
+
+        if (!Objects.equals(roadmap.getUser().getId(), userPrincipal.getId()))
+            throw new RoadmapMismatchUserException();
+
+        University university = University.of(user.getUniversity());
+        String title = roadmap.getTitle();
+        RecommendLectureRes lecture;
+
+        if (title.equals("창업 교육") || title.equals("아이디어 창출") || title.equals("공간 마련") || title.equals("사업계획서 작성")) {
+            lecture = lectureRepository.findRandomLectureByUniversity(user.getId(), university);
+            return lecture;
+        }
+
+        return null;
+    }
+
+    @Override
+    public RoadmapSystemRes recommendSystem(final UserPrincipal userPrincipal, final Long roadmapId) {
+        User user = userRepository.findById(userPrincipal.getId())
+                .orElseThrow(InvalidUserException::new);
+
+        Roadmap roadmap = roadmapRepository.findById(roadmapId)
+                .orElseThrow(InvalidRoadmapException::new);
+
+        if (!Objects.equals(roadmap.getUser().getId(), userPrincipal.getId()))
+            throw new RoadmapMismatchUserException();
+
+        University university = University.of(user.getUniversity());
+        String title = roadmap.getTitle();
+        RoadmapSystemRes system;
+
+        if (title.equals("창업 교육") || title.equals("아이디어 창출") || title.equals("공간 마련") || title.equals("사업계획서 작성")) {
+            system = announcementRepository.findRandomSystemByUniversity(user.getId(), university);
+            return system;
+        }
+
+        return null;
     }
 
 }

--- a/src/main/java/com/startingblock/domain/roadmap/presentation/RoadmapController.java
+++ b/src/main/java/com/startingblock/domain/roadmap/presentation/RoadmapController.java
@@ -1,8 +1,6 @@
 package com.startingblock.domain.roadmap.presentation;
 
-import com.startingblock.domain.announcement.dto.AnnouncementRes;
-import com.startingblock.domain.announcement.dto.RecommendAnnouncementRes;
-import com.startingblock.domain.announcement.dto.RoadmapLectureRes;
+import com.startingblock.domain.announcement.dto.*;
 import com.startingblock.domain.roadmap.dto.RoadmapAnnouncementRes;
 import com.startingblock.domain.roadmap.application.RoadmapService;
 import com.startingblock.domain.roadmap.dto.SavedRoadmapRes;
@@ -249,6 +247,32 @@ public class RoadmapController {
             @Parameter(name = "roadmap-id", description = "로드맵 ID") @PathVariable(name = "roadmap-id") final Long roadmapId
     ) {
         return ResponseEntity.ok(roadmapService.recommendOnCampusAnnouncements(userPrincipal, roadmapId));
+    }
+
+    @Operation(summary = "교내 강의 추천 조회", description = "교내 강의 추천 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "교내 강의 추천 조회 성공", content = {@Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = RecommendLectureRes.class)))}),
+            @ApiResponse(responseCode = "400", description = "교내 강의 추천 조회 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})
+    })
+    @GetMapping("/{roadmap-id}/recommend/class")
+    public ResponseEntity<RecommendLectureRes> recommendLecture(
+            @Parameter(name = "Authorization Token") @CurrentUser final UserPrincipal userPrincipal,
+            @Parameter(name = "roadmap-id", description = "로드맵 ID") @PathVariable(name = "roadmap-id") final Long roadmapId
+    ) {
+        return ResponseEntity.ok(roadmapService.recommendLecture(userPrincipal, roadmapId));
+    }
+
+    @Operation(summary = "교내 제도 추천 조회", description = "교내 제도 추천 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "교내 제도 추천 조회 성공", content = {@Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = RoadmapSystemRes.class)))}),
+            @ApiResponse(responseCode = "400", description = "교내 제도 추천 조회 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})
+    })
+    @GetMapping("/{roadmap-id}/recommend/system")
+    public ResponseEntity<RoadmapSystemRes> recommendSystem(
+            @Parameter(name = "Authorization Token") @CurrentUser final UserPrincipal userPrincipal,
+            @Parameter(name = "roadmap-id", description = "로드맵 ID") @PathVariable(name = "roadmap-id") final Long roadmapId
+    ) {
+        return ResponseEntity.ok(roadmapService.recommendSystem(userPrincipal, roadmapId));
     }
 
 }

--- a/src/main/java/com/startingblock/domain/user/presentation/UserController.java
+++ b/src/main/java/com/startingblock/domain/user/presentation/UserController.java
@@ -72,7 +72,7 @@ public class UserController {
     @PatchMapping("/nickname")
     public ResponseEntity<Void> updateUserNickname(
             @Parameter(description = "AccessToken 을 입력해주세요.", required = true) @CurrentUser final UserPrincipal userPrincipal,
-            @Parameter(description = "SignUpUserReq 를 확인해주세요.", required = true) @RequestParam final String nickname
+            @Parameter(name = "nickname", description = "nickname", required = true) @RequestParam final String nickname
     ) {
         userService.updateUserNickname(userPrincipal, nickname);
         return ResponseEntity.noContent().build();


### PR DESCRIPTION
* fix: 로드맵에 창업강의 저장되어 있을 때 삭제 안되는 현상 해결

* fix: 창업강의가 없는 로드맵 조회시 에러 해결 + lectureId 컬럼 추가

* feat: OFF-CAMPUS 공고 isContactExist, isFileUploaded 컬럼 추가

* feat: OFF-CAMPUS 공고 조회 시 ON-CAMPUS 관련 공고 제외

* feat: 교내 지원 공고 조회 API search 파라미터 추가

* feat: 닉네임 변경 API 분리 + profileNumber 컬럼 추가

* feat: 현재 토큰 유저 조회 API profileNumber Response 추가

* feat: 현재 토큰 유저 조회 API profileNumber Response 추가

* feat: 교외 공고 추천 API 구현

* feat: 교내 공고 추천 API 구현

* feat: 교내 창업 강의 추천 API 구현

* feat: 교내 창업 제도 추천 API 구현

- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.`
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?
## 작업 내용

## 스크린샷

## 주의사항

Closes #{이슈 번호}